### PR TITLE
feat: k3s deployment scaffolding and GHCR image publish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.claude
+node_modules
+dist
+out
+coverage
+npm-debug.log*
+Dockerfile
+specs

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,34 @@
+name: Publish container image
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/mzakhar/audio-tools:main
+            ghcr.io/mzakhar/audio-tools:sha-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-alpine AS build
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+COPY electron.vite.config.js ./
+COPY src ./src
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY deploy/nginx/synth.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/out/renderer /usr/share/nginx/html
+
+EXPOSE 8080
+

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: synth
+  namespace: synth
+  labels:
+    app.kubernetes.io/name: synth
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: synth
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: synth
+    spec:
+      containers:
+        - name: synth
+          image: ghcr.io/mzakhar/audio-tools:main
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi

--- a/deploy/k8s/ingress.yaml
+++ b/deploy/k8s/ingress.yaml
@@ -1,0 +1,46 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: synth
+  namespace: synth
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: synth-synth-strip-prefix@kubernetescrd
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /synth
+            pathType: Prefix
+            backend:
+              service:
+                name: synth
+                port:
+                  name: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: synth-external
+  namespace: synth
+spec:
+  rules:
+    - host: synth.zakharhome.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: synth
+                port:
+                  name: http
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: synth-strip-prefix
+  namespace: synth
+spec:
+  stripPrefix:
+    prefixes:
+      - /synth

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: synth

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: synth
+  namespace: synth
+  labels:
+    app.kubernetes.io/name: synth
+spec:
+  selector:
+    app.kubernetes.io/name: synth
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/deploy/nginx/synth.conf
+++ b/deploy/nginx/synth.conf
@@ -1,0 +1,17 @@
+server {
+  listen 8080;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location = /healthz {
+    access_log off;
+    add_header Content-Type text/plain;
+    return 200 "ok\n";
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/deploy/systemd/synth-deploy.service
+++ b/deploy/systemd/synth-deploy.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Pull and deploy Synth to local k3s
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+Environment=APP_DIR=%h/apps/synth
+Environment=REPO_URL=https://github.com/mzakhar/Audio-Tools.git
+Environment=BRANCH=main
+ExecStart=%h/apps/synth/scripts/deploy-k3s.sh

--- a/deploy/systemd/synth-deploy.timer
+++ b/deploy/systemd/synth-deploy.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Poll GitHub and deploy Synth to local k3s
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Unit=synth-deploy.service
+
+[Install]
+WantedBy=timers.target

--- a/electron.vite.config.js
+++ b/electron.vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
     plugins: [externalizeDepsPlugin()]
   },
   renderer: {
+    base: './',
     root: 'src/renderer',
     build: {
       rollupOptions: {

--- a/scripts/deploy-k3s.sh
+++ b/scripts/deploy-k3s.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+set -eu
+
+APP_DIR="${APP_DIR:-$HOME/apps/synth}"
+REPO_URL="${REPO_URL:-https://github.com/mzakhar/Audio-Tools.git}"
+BRANCH="${BRANCH:-main}"
+
+if [ ! -d "$APP_DIR/.git" ]; then
+  mkdir -p "$(dirname "$APP_DIR")"
+  git clone --branch "$BRANCH" "$REPO_URL" "$APP_DIR"
+fi
+
+cd "$APP_DIR"
+git fetch origin "$BRANCH"
+git checkout "$BRANCH"
+git reset --hard "origin/$BRANCH"
+
+kubectl apply -k deploy/k8s
+kubectl -n synth rollout restart deployment/synth
+kubectl -n synth rollout status deployment/synth --timeout=120s


### PR DESCRIPTION
## Summary
- Container image publish workflow: builds and pushes to `ghcr.io/mzakhar/audio-tools:main` on push to `main`.
- k8s manifests: namespace `synth`, deployment, service, and two Ingresses — LAN subpath `/synth` (with StripPrefix middleware) and external host `synth.zakharhome.org` (no middleware).
- Docker build and container smoke-tested locally: `/healthz` returns ok, relative asset paths verified.

## Test plan
- [x] Local `docker build` succeeds
- [x] Container serves app with `/healthz` ok
- [x] Static asset paths resolve correctly at both `/` and `/synth/` mount points

🤖 Generated with [Claude Code](https://claude.com/claude-code)