### PR TITLE
chore(deploy): add a script to trigger a Synth rollout

### DIFF
--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+# Trigger a Synth rollout on themachine.
+#
+# Flux reconciles deploy/k8s and is not the problem: it tracks main correctly.
+# The gap is that deploy/k8s/deployment.yaml pins the *moving* tag
+# ghcr.io/mzakhar/audio-tools:main. A merge that touches no manifest leaves the
+# Deployment spec byte-identical, so Flux applies the same YAML, Kubernetes sees
+# no change, and no new pod is created — the running container keeps serving the
+# old image from behind the same tag. imagePullPolicy: Always only takes effect
+# when a pod is created, and nothing creates one.
+#
+# This cluster runs only the helm/kustomize/notification/source controllers, so
+# there is no image-reflector or image-automation controller to notice that the
+# tag moved. Until there is, the rollout has to be asked for.
+#
+# ponytail: a restart, not real GitOps — nothing records which build is live.
+# The proper fix is to pin the immutable sha-<commit> tag and let CI commit the
+# bump, so Flux has genuine drift to reconcile. Worth doing if deploys ever need
+# to be auditable, or to happen without a human running this.
+set -eu
+
+HOST="${SYNTH_HOST:-mzakhar@themachine}"
+
+# Restarting onto an image that has not finished publishing is the exact
+# "my change isn't there" confusion this script exists to fix, so check first.
+# Skipped without gh, or with SKIP_IMAGE_CHECK=1.
+if [ "${SKIP_IMAGE_CHECK:-0}" != "1" ] && command -v gh >/dev/null 2>&1; then
+  sha=$(git rev-parse origin/main)
+  status=$(gh run list --workflow publish-image.yml --limit 20 \
+    --json headSha,conclusion --jq "map(select(.headSha==\"$sha\")) | .[0].conclusion" 2>/dev/null || echo '')
+  case "$status" in
+    success) echo "image published for ${sha%"${sha#???????}"}" ;;
+    '' | null) echo "WARNING: no completed publish-image run for $sha — the pod may come back on an older image" ;;
+    *) echo "WARNING: publish-image for $sha concluded '$status' — the pod may come back on an older image" ;;
+  esac
+fi
+
+ssh "$HOST" '
+  set -eu
+  kubectl -n synth rollout restart deployment/synth
+  kubectl -n synth rollout status deployment/synth --timeout=120s
+  kubectl -n synth get pods -o wide
+'


### PR DESCRIPTION
Flux tracks `main` correctly — it had already reconciled `2c51d43` when the pod was still 10h old and serving the previous image. The gap is one link later: `deploy/k8s/deployment.yaml` pins the *moving* tag `:main`, so a merge that touches no manifest leaves the Deployment spec byte-identical. Flux applies the same YAML, Kubernetes sees no change, no pod is created, and the running container keeps serving the old image from behind the same tag. `imagePullPolicy: Always` only takes effect when a pod is created.

The cluster runs only `helm-`, `kustomize-`, `notification-` and `source-controller` — no `image-reflector`/`image-automation` — so nothing watches GHCR for the tag moving.

`scripts/redeploy.sh` asks for the rollout, after checking that `publish-image` actually succeeded for `origin/main`'s SHA. Restarting onto a half-published image reproduces the exact "my change isn't there" confusion the script exists to fix. `SYNTH_HOST` overrides the target; `SKIP_IMAGE_CHECK=1` skips the guard.

Deliberately not a reuse of `scripts/deploy-k3s.sh`: that clones the repo to `~/apps/synth` and runs `kubectl apply -k`, which fights Flux for ownership of those resources. It stays the systemd-timer fallback.

Carries a `ponytail:` note that this is a restart, not real GitOps — nothing records which build is live. The proper fix is pinning the immutable `sha-<commit>` tag with CI committing the bump, so Flux has genuine drift to reconcile.

Verified by running it: rollout completed, new pod on `sha256:4759a8e9…`, `/synth/healthz` 200, and the served bundle carries the newly merged modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuLrfnEjBGpWqvuRAASBcd