### PR TITLE
feat(909): programmable bars with chain playback + shared transport header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 .claude/settings.local.json
 *.log
 .DS_Store
+.chrome-debug/
+.chrome-visible-debug/

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+# Trigger a Synth rollout on themachine.
+#
+# Flux reconciles deploy/k8s and is not the problem: it tracks main correctly.
+# The gap is that deploy/k8s/deployment.yaml pins the *moving* tag
+# ghcr.io/mzakhar/audio-tools:main. A merge that touches no manifest leaves the
+# Deployment spec byte-identical, so Flux applies the same YAML, Kubernetes sees
+# no change, and no new pod is created — the running container keeps serving the
+# old image from behind the same tag. imagePullPolicy: Always only takes effect
+# when a pod is created, and nothing creates one.
+#
+# This cluster runs only the helm/kustomize/notification/source controllers, so
+# there is no image-reflector or image-automation controller to notice that the
+# tag moved. Until there is, the rollout has to be asked for.
+#
+# ponytail: a restart, not real GitOps — nothing records which build is live.
+# The proper fix is to pin the immutable sha-<commit> tag and let CI commit the
+# bump, so Flux has genuine drift to reconcile. Worth doing if deploys ever need
+# to be auditable, or to happen without a human running this.
+set -eu
+
+HOST="${SYNTH_HOST:-mzakhar@themachine}"
+
+# Restarting onto an image that has not finished publishing is the exact
+# "my change isn't there" confusion this script exists to fix, so check first.
+# Skipped without gh, or with SKIP_IMAGE_CHECK=1.
+if [ "${SKIP_IMAGE_CHECK:-0}" != "1" ] && command -v gh >/dev/null 2>&1; then
+  sha=$(git rev-parse origin/main)
+  status=$(gh run list --workflow publish-image.yml --limit 20 \
+    --json headSha,conclusion --jq "map(select(.headSha==\"$sha\")) | .[0].conclusion" 2>/dev/null || echo '')
+  case "$status" in
+    success) echo "image published for ${sha%"${sha#???????}"}" ;;
+    '' | null) echo "WARNING: no completed publish-image run for $sha — the pod may come back on an older image" ;;
+    *) echo "WARNING: publish-image for $sha concluded '$status' — the pod may come back on an older image" ;;
+  esac
+fi
+
+ssh "$HOST" '
+  set -eu
+  kubectl -n synth rollout restart deployment/synth
+  kubectl -n synth rollout status deployment/synth --timeout=120s
+  kubectl -n synth get pods -o wide
+'

--- a/specs/shared-transport-header.md
+++ b/specs/shared-transport-header.md
@@ -1,0 +1,121 @@
+# Shared transport header
+
+Status: spec, not built.
+
+## Problem
+
+BPM, master volume and transport are scattered and inconsistent. What exists
+today:
+
+| Control | Where | Element | Wiring |
+|---|---|---|---|
+| BPM (slider) | synth view, bottom of `#sequencer-section` | `#bpm-slider` | `app.js:291` `initBPM()` |
+| BPM (number) | arrange toolbar | `#arr-bpm` | `app.js:710` `initArrangeTransport()` |
+| Master volume | synth `#header` only | `#master-vol` | `app.js:268` `initMasterVolume()` |
+| Transport | synth `.transport` | `#play-btn` `#stop-btn` `#clear-btn` | `app.js:738` |
+| Transport | arrange toolbar | `#arr-play-btn` `#arr-stop-btn` | `app.js:673` |
+| Transport | 909 view | rendered inside `tr909-view.js:58` | component-local |
+
+Consequences: BPM is two different input types bound to the same
+`ProjectStore.state.bpm`; the rack view has no BPM or volume at all; master
+volume disappears when you leave the synth view; and the play button physically
+moves depending on which tool is open.
+
+## Design
+
+One header row, `#global-header`, placed inside `#main` **above** `#project-bar`,
+visible in every view:
+
+```
+#main
+  #global-header    ← BPM | master volume | transport | (view-specific slot)
+  #project-bar      ← project/audio/MIDI/bounce — unchanged
+  #arrange-view / #rack-view / #app
+```
+
+Contents, left to right:
+
+- **BPM** — one control for all views. Number input (`#arr-bpm`'s type), not a
+  slider: typing `128` is the common action and a slider cannot do it.
+  Range 40–240. Writes `ProjectStore.dispatch(SetBpm(v))`.
+- **Master volume** — the existing `#master-vol` range plus `#master-vol-display`,
+  moved verbatim out of `#header`.
+- **Transport** — `Play` / `Stop`. These stay **mode-aware**: `app.js:738`
+  already branches on the active tool to drive `Sequencer` vs `TimelinePlayer`;
+  that dispatch logic moves to the shared buttons unchanged.
+- **View slot** — an empty `<div id="header-view-slot">` for controls that are
+  genuinely view-specific. The 909 bar strip is the first tenant.
+
+## What gets removed
+
+- `#bpm-slider`, `#bpm-display` and the `.bpm-group` wrapper in
+  `#sequencer-controls`.
+- `#arr-bpm` and its label from `#arrange-toolbar`.
+- `#master-vol-wrap` from `#header` (the element moves, it is not rebuilt).
+- `#arr-play-btn` / `#arr-stop-btn`; `#arrange-toolbar` keeps only what is
+  actually arrange-specific.
+- The synth `.transport` keeps `Clear` and `+ Track` — those are sequencer
+  actions, not transport — and loses `Play`/`Stop`.
+
+`initBPM()` and `initArrangeTransport()` collapse into one `initGlobalHeader()`.
+
+## What does *not* move
+
+- **909 transport stays in the 909 view.** The 909 has two play modes (bar and
+  chain, per `tr-909-pattern-bars.md`) and a global two-button transport cannot
+  express that. The shared `Play` is a no-op — greyed with a tooltip — while the
+  909 palette is active, or it maps to `Play Chain`. Pick one during
+  implementation and be consistent; do not render a live global Play that
+  silently does nothing.
+- `#project-bar` contents. Project open/save, audio import, MIDI and bounce are
+  not transport and stay where they are.
+- Per-channel mixer volume. Unrelated to master.
+
+## No component abstraction
+
+The header is static markup in `index.html` wired once in `app.js`, matching how
+`#project-bar` and `#arrange-toolbar` already work. There is exactly one header
+and there will not be a second, so a `Header` component class with a `mode`
+prop would be one implementation behind an interface. Show/hide the view slot's
+contents; do not build a renderer.
+
+## BPM as the single source
+
+`ProjectStore.state.bpm` is already the source of truth (`ProjectStore.js:17`,
+`SetBpm` at `:108`), but `Sequencer` also holds a BPM (`Sequencer.setBPM`, read
+by `tr909-view.js:361` via `Sequencer.getBPM()`). The header writes to the
+store; the store subscription pushes into `Sequencer.setBPM()` in one place.
+Anything that reads tempo keeps reading whichever of the two it reads today —
+this spec does not unify the readers, only the writers. Removing
+`Sequencer`'s copy is a separate cleanup.
+
+Verify while implementing: with the header BPM changed mid-playback, both the
+sequencer and the 909 step duration follow. `tr909-view.js:361` recomputes
+`stepDuration()` per step, so it should — confirm rather than assume.
+
+## Layout / CSS
+
+- `#global-header` is a flex row, same visual weight as `#project-bar`
+  (reuse its border/background tokens rather than inventing new ones).
+- Reuse existing classes: `.transport-btn`, `.knob-label`, `.knob-val`. No new
+  button styling.
+- Narrow widths: the view slot wraps below the shared controls. The header must
+  not push the arrangement canvas off-screen.
+
+## Test plan
+
+Mostly manual — this is markup movement, and there is no DOM test harness for
+`app.js` today.
+
+1. BPM change in synth view → arrange playback tempo matches.
+2. BPM change in arrange view → 909 step duration matches.
+3. Master volume is present and functional in all four views (synth, 909,
+   arrange, rack).
+4. Play/Stop drive the sequencer in synth view and the timeline in arrange view,
+   as they do now.
+5. Switching views does not reset BPM or volume.
+
+## Order of work
+
+Land this **before** the 909 bar strip. The bar strip wants the header's view
+slot, and doing the header second means moving the strip twice.

--- a/specs/tr-909-pattern-bars.md
+++ b/specs/tr-909-pattern-bars.md
@@ -1,0 +1,216 @@
+# TR-909 — Pattern bars and bar chaining
+
+Status: spec, not built. Supersedes the dead `Pattern` dropdown at
+`src/renderer/js/components/tr909-view.js:69`.
+
+## Problem
+
+The 909 view holds exactly one pattern, in component state
+(`tr909-view.js:36`, `this.pattern = makePattern()`). It is never persisted, so
+everything programmed is lost when the view unmounts or the app reloads. The
+`Pattern` `<select>` renders four slots `A1–A4` and has **no event listener at
+all** — it is cosmetic markup.
+
+What is wanted:
+
+1. Program several bars.
+2. Copy the current bar into a new bar (the fast way to build a variation).
+3. Play the whole chain of bars sequentially from the 909 screen.
+4. See how many bars exist, as buttons rather than a dropdown.
+5. While the chain plays, the current bar's button glows.
+
+## Decisions taken
+
+| Question | Decision |
+|---|---|
+| Bar length | Fixed 16 steps. `lastStep` stays a per-bar loop-length control. |
+| Persistence | Yes — bars live in `ProjectStore.state.patterns`, schema 2 → 3. |
+| Arrangement | Out of scope. Chain plays from the 909 screen only. Arrange clips referencing a `patternId` remain the 909 spec's Phase D. |
+
+## Data model
+
+`ProjectStore.state.patterns` is currently `{}` and reserved
+(`ProjectStore.js:25`). The 909 claims one well-known key:
+
+```js
+state.patterns['909-main'] = {
+  id: '909-main',
+  name: '909',
+  currentBar: 0,          // which bar the editor is showing
+  chain: [0, 1, 1, 2],    // play order — indices into bars[]
+  bars: [
+    {
+      id: 'bar-1-...',
+      // everything that used to live on `this.pattern`, minus `name`
+      scale: '1/16',
+      shuffle: 0,
+      flam: 0.18,
+      lastStep: 16,
+      totalAccent: 0.45,
+      lanes: { bd: Step[16], sd: Step[16], ... }   // one entry per INSTRUMENTS id
+    }
+  ]
+}
+```
+
+`Step` is unchanged: `{ on, velocity, accent, flam }`.
+
+Notes on the shape:
+
+- **Per-bar globals.** `shuffle`, `flam`, `lastStep`, `totalAccent` and `scale`
+  live on the bar, not the pattern. A half-time fill with a different shuffle is
+  the whole point of having bars; hoisting them to the pattern would forbid it.
+  The existing global sliders edit the *current* bar.
+- **`chain` is separate from `bars`.** A chain entry is an index, so a bar can
+  repeat (`[0,0,0,1]`) without duplicating its lanes. Default chain is
+  `[0, 1, ..., n-1]` — one pass per bar in order.
+- **`kitParams` stays out.** Kit tuning is an instrument-level setting, not a
+  per-bar one, and is not part of this spec. It stays in component state until
+  a later persistence pass covers it.
+
+## Store commands
+
+Follow the existing command pattern (`label`, pure `execute(state) → next`,
+deep-clone first, as in `SetModuleParam` at `ProjectStore.js:542`). One private
+helper mirrors `rackCommand` (`ProjectStore.js:460`):
+
+```js
+function patternCommand(label, patternId, mutate)   // clone, ensure pattern exists, mutate, return
+```
+
+| Command | Behaviour |
+|---|---|
+| `SetPatternStep(patternId, barIndex, instrumentId, stepIndex, patch)` | Merge `patch` into one step. Covers on/off, velocity, accent, flam. |
+| `SetBarParam(patternId, barIndex, key, value)` | One of `scale`, `shuffle`, `flam`, `lastStep`, `totalAccent`. |
+| `AddBar(patternId, { copyFrom = null })` | Append a bar. `copyFrom` is a bar index → deep copy of that bar with a fresh `id`; `null` → empty bar. Appends its index to `chain`. |
+| `RemoveBar(patternId, barIndex)` | Delete the bar, drop every `chain` entry pointing at it, and **decrement** every chain index above it. Refuses to remove the last remaining bar. |
+| `SetCurrentBar(patternId, barIndex)` | Editor selection only. |
+| `SetChain(patternId, chain)` | Replace the play order wholesale. |
+| `ClearBar(patternId, barIndex)` | Reset all lanes of one bar to off. Replaces the current `Clear` button's behaviour. |
+
+`SetCurrentBar` is a selection change, not an edit. It still goes through
+`dispatch` for consistency, but it is the one command a reviewer should expect
+to see churn the undo stack — if that gets annoying in use, make it a plain
+non-undoable setter rather than special-casing the history.
+
+### Migration
+
+```js
+if ((next.version ?? 1) < 3) {
+  if (!next.patterns) next.patterns = {}
+  next.version = 3
+}
+```
+
+Bump `CURRENT_VERSION` to 3. No projects contain 909 data today, so migration
+only has to guarantee the key exists. `Tr909View` creates `'909-main'` lazily on
+first mount if absent.
+
+## Playback
+
+Today `play()` (`tr909-view.js:305`) builds a `LookaheadScheduler` over
+`this.pattern.lastStep` and loops that one bar forever.
+
+Two transport modes:
+
+| Mode | Loop unit |
+|---|---|
+| **Bar** (default) | The current bar, looped — exactly today's behaviour. |
+| **Chain** | Walk `chain` in order, wrapping at the end. |
+
+Chain mode is a step-boundary concern, not a second scheduler. `scheduleStep`
+already receives `(stepIndex, time)`; the only change is *which bar* it reads
+lanes from:
+
+- Keep a `playChainPos` cursor into `chain`.
+- The scheduler's `steps` is the playing bar's `lastStep`. When the scheduler
+  wraps from `lastStep - 1` back to `0` in chain mode, advance
+  `playChainPos = (playChainPos + 1) % chain.length` **at schedule time, not at
+  playhead time** — the audio thread is ahead of the display.
+- `scheduleStep` resolves `bars[chain[playChainPos]]` and reads its lanes,
+  shuffle, flam and accent from there.
+
+Because bars can have different `lastStep`, the scheduler's step count must be
+re-read per wrap rather than fixed at `start()`. Check whether
+`LookaheadScheduler` (`src/renderer/js/rack/scheduler.js`) reads `steps` each
+tick or captures it once; if it captures it, pass a getter instead of a number.
+That is the one place this design can break, so it is worth confirming before
+writing the UI.
+
+**Bar advance must be derived from scheduled time, not from the playhead RAF
+loop.** The RAF loop (`tr909-view.js:365`) exists only to paint. It reads
+`schedulerLoop.stepTimes` and compares against `ctx.currentTime`; it must also
+learn which *bar* is currently sounding to drive the glow. Cheapest correct
+approach: record `barAtStepTime[stepIndex]` alongside `stepTimes` when
+scheduling, and have the RAF loop read the bar out of that array using the same
+`bestStep` it already computes. No new timing source.
+
+## UI
+
+Replace the `Pattern` `<select>` block (`tr909-view.js:64–71`) with a bar strip:
+
+```
+BARS  [1] [2] [3] [+]        ⧉ Copy Bar     ▸ Bar  ▸ Chain   ■ Stop
+```
+
+- **Bar buttons** — one per entry in `bars[]`, numbered from 1. Click selects
+  (`SetCurrentBar`). They are the visual count of saved bars, replacing the
+  dropdown.
+- **Two glow states, visually distinct**:
+  - *selected* — the bar the editor is showing (persistent outline).
+  - *playing* — the bar currently sounding in chain mode (animated/bright fill).
+    They can be the same bar; the styles must compose, not overwrite.
+- **`+`** — `AddBar` with `copyFrom: null`, an empty bar.
+- **Copy Bar** — `AddBar` with `copyFrom: currentBar`, then select the new bar.
+  This is the requested "copy the current bar into a new bar".
+- **Remove** — shift-click or a small `×` on the button; guarded so the last bar
+  cannot be deleted.
+- **Transport** — `Play Bar` and `Play Chain` as separate buttons, sharing one
+  `Stop`. Two buttons beat one mode toggle: auditioning the bar you are editing
+  and hearing the whole arrangement are different intents and both are wanted
+  constantly. Only one can be active; starting one stops the other.
+- The `Clear` button now means `ClearBar(currentBar)`.
+
+Accessibility: the bar strip is `role="toolbar"`, buttons carry
+`aria-pressed` for selection and `aria-current="true"` for the playing bar.
+
+### Rendering
+
+`Tr909View.render()` currently rebuilds the entire innerHTML. Do **not** call
+it on every playhead frame or bar advance — the glow update belongs with
+`updatePlayhead()` (`tr909-view.js:388`), toggling a class on the bar buttons.
+Full re-render is fine on bar add/remove/select.
+
+## Store subscription
+
+`Tr909View` reads its pattern from `ProjectStore.getState().patterns['909-main']`
+and subscribes for external changes (undo/redo). Re-render on subscription fire
+**only if the pattern object actually changed** — the store notifies every
+listener on every dispatch, including unrelated mixer moves, and a full
+innerHTML rebuild on each would kill step-button interaction. Compare by
+reference against the last-seen pattern.
+
+## Test plan
+
+Store commands are pure, so they test directly — no DOM, matching how the rack
+commands are covered.
+
+| Test | Asserts |
+|---|---|
+| `AddBar` with `copyFrom` | new bar's lanes deep-equal the source, `id` differs, mutating one does not touch the other |
+| `AddBar` empty | all steps `on: false`, appended to `chain` |
+| `RemoveBar` middle index | chain entries above it decrement, entries pointing at it vanish |
+| `RemoveBar` last remaining | state unchanged |
+| `SetPatternStep` | only the addressed step changes |
+| `migrate` from v2 | `patterns` exists, `version === 3`, existing tracks/racks untouched |
+| chain cursor | pure helper `nextChainPos(pos, chainLength)` wraps correctly |
+
+Playback timing is not unit-tested here; the existing scheduler tests cover the
+lookahead itself.
+
+## Out of scope
+
+- Pattern banks (multiple named patterns beyond `'909-main'`).
+- Arrangement clips referencing a pattern — 909 spec Phase D.
+- Persisting `kitParams`.
+- Per-bar tempo or time signature.

--- a/specs/tr-909-pattern-bars.md
+++ b/specs/tr-909-pattern-bars.md
@@ -131,11 +131,19 @@ lanes from:
   shuffle, flam and accent from there.
 
 Because bars can have different `lastStep`, the scheduler's step count must be
-re-read per wrap rather than fixed at `start()`. Check whether
-`LookaheadScheduler` (`src/renderer/js/rack/scheduler.js`) reads `steps` each
-tick or captures it once; if it captures it, pass a getter instead of a number.
-That is the one place this design can break, so it is worth confirming before
-writing the UI.
+re-read per wrap rather than fixed at `start()`. **Verified**: `LookaheadScheduler`
+(`src/renderer/js/rack/scheduler.js`) evaluates `this.steps` inside `tick()`
+(`this.step = (this.step + 1) % this.steps`), so assigning
+`schedulerLoop.steps = n` between wraps takes effect immediately. No getter
+needed.
+
+The assignment must happen **at `stepIndex === 0`, not at the last step of the
+outgoing bar**. The wrap `(lastStep - 1 + 1) % steps` has to use the *outgoing*
+bar's `lastStep` to land on 0; swapping `steps` before that increment gives
+`lastStep % newSteps`, which is not 0 when the next bar is longer. So:
+`scheduleStep(0, …)` advances `playChainPos` (except on the very first
+scheduled step) and only then assigns the new bar's `lastStep` to
+`schedulerLoop.steps`.
 
 **Bar advance must be derived from scheduled time, not from the playhead RAF
 loop.** The RAF loop (`tr909-view.js:365`) exists only to paint. It reads

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -24,6 +24,18 @@
       </button>
     </nav>
     <div id="main">
+    <div id="global-header" role="toolbar" aria-label="Global transport">
+      <label class="knob-label" for="global-bpm">BPM</label>
+      <input type="number" id="global-bpm" min="40" max="240" value="120" aria-label="Tempo in BPM">
+      <div id="master-vol-wrap">
+        <label class="knob-label" for="master-vol">VOL</label>
+        <input type="range" id="master-vol" min="0" max="1" step="0.01" value="0.8" aria-label="Master volume">
+        <span class="knob-val" id="master-vol-display" aria-hidden="true">80</span>
+      </div>
+      <button id="global-play-btn" class="transport-btn play" aria-pressed="false">▶ Play</button>
+      <button id="global-stop-btn" class="transport-btn stop">■ Stop</button>
+      <div id="header-view-slot"></div>
+    </div>
     <div id="project-bar" role="toolbar" aria-label="Project controls">
       <button id="new-project-btn" title="New project (Ctrl+N)">NEW</button>
       <button id="open-project-btn" title="Open project (Ctrl+O)">OPEN</button>
@@ -42,11 +54,6 @@
     </div>
     <div id="arrange-view">
       <div id="arrange-toolbar" role="toolbar" aria-label="Arrange transport">
-        <button id="arr-play-btn" class="transport-btn play" aria-pressed="false">▶ Play</button>
-        <button id="arr-stop-btn" class="transport-btn stop">■ Stop</button>
-        <label class="knob-label" for="arr-bpm">BPM</label>
-        <input type="number" id="arr-bpm" min="40" max="240" value="120" aria-label="Tempo in BPM">
-        <span class="project-bar-sep" aria-hidden="true"></span>
         <button id="arr-add-track-btn" class="transport-btn">+ TRACK</button>
       </div>
       <div id="arrangement-container" aria-label="Arrangement timeline" role="region"></div>
@@ -88,11 +95,6 @@
         <button class="tab" data-palette="tr909" role="tab" aria-selected="false">909</button>
         <button class="tab" data-palette="pad" role="tab" aria-selected="false">PAD / AMBIENT</button>
       </div>
-      <div id="master-vol-wrap">
-        <label class="knob-label" for="master-vol">VOL</label>
-        <input type="range" id="master-vol" min="0" max="1" step="0.01" value="0.8" aria-label="Master volume">
-        <span class="knob-val" id="master-vol-display" aria-hidden="true">80</span>
-      </div>
     </header>
 
     <div id="record-bar" role="toolbar" aria-label="Recorder">
@@ -124,15 +126,8 @@
       <div id="seq-tracks"></div>
       <div id="sequencer-controls">
         <div class="transport" role="toolbar" aria-label="Transport">
-          <button id="play-btn" class="transport-btn play" aria-pressed="false">▶ Play</button>
-          <button id="stop-btn" class="transport-btn stop">■ Stop</button>
           <button id="clear-btn" class="transport-btn clear">✕ Clear</button>
           <button id="add-track-btn" class="transport-btn">+ Track</button>
-        </div>
-        <div class="bpm-group">
-          <label class="knob-label" for="bpm-slider">BPM</label>
-          <input type="range" id="bpm-slider" min="40" max="220" value="120" step="1" aria-label="Beats per minute">
-          <span class="knob-val" id="bpm-display" aria-hidden="true">120</span>
         </div>
       </div>
     </section>

--- a/src/renderer/js/app.js
+++ b/src/renderer/js/app.js
@@ -94,12 +94,19 @@ function switchPalette(key) {
   document.getElementById('drum-pads').style.display    = isDrum ? 'flex' : 'none'
   document.getElementById('drum-hint').style.display    = isDrum ? '' : 'none'
 
-  // 909 has its own Bar/Chain transport; the shared Play is meaningless there.
-  const globalPlayBtn = document.getElementById('global-play-btn')
-  if (globalPlayBtn) {
-    globalPlayBtn.disabled = is909
-    globalPlayBtn.title = is909 ? '909 uses its own Bar/Chain transport' : ''
-  }
+  updateGlobalPlayAvailability()
+}
+
+// The 909 has its own Bar/Chain transport, so the shared Play is meaningless
+// while it is on screen. Derived from both mode and palette and called from
+// both switches — keying it off the palette alone left Play stuck disabled
+// after leaving the 909 for arrange or rack, which never re-run switchPalette.
+function updateGlobalPlayAvailability() {
+  const btn = document.getElementById('global-play-btn')
+  if (!btn) return
+  const on909 = _currentMode === 'synth' && currentPaletteKey === 'tr909'
+  btn.disabled = on909
+  btn.title = on909 ? '909 uses its own Bar/Chain transport' : ''
 }
 
 // ─── Drum pads ─────────────────────────────────────────────────────────────
@@ -422,6 +429,7 @@ function initRecorder() {
 // ─── Mode switching ──────────────────────────────────────────────────────────
 function switchMode(mode) {
   _currentMode = mode
+  updateGlobalPlayAvailability()
   const appEl     = document.getElementById('app')
   const arrangeEl = document.getElementById('arrange-view')
   const rackEl = document.getElementById('rack-view')

--- a/src/renderer/js/app.js
+++ b/src/renderer/js/app.js
@@ -93,6 +93,13 @@ function switchPalette(key) {
   document.getElementById('keyboard-hint').style.display = isDrum ? 'none' : ''
   document.getElementById('drum-pads').style.display    = isDrum ? 'flex' : 'none'
   document.getElementById('drum-hint').style.display    = isDrum ? '' : 'none'
+
+  // 909 has its own Bar/Chain transport; the shared Play is meaningless there.
+  const globalPlayBtn = document.getElementById('global-play-btn')
+  if (globalPlayBtn) {
+    globalPlayBtn.disabled = is909
+    globalPlayBtn.title = is909 ? '909 uses its own Bar/Chain transport' : ''
+  }
 }
 
 // ─── Drum pads ─────────────────────────────────────────────────────────────
@@ -264,45 +271,64 @@ function addDivider(panel) {
   panel.appendChild(div)
 }
 
-// ─── Master volume ──────────────────────────────────────────────────────────
-function initMasterVolume() {
-  const slider = document.getElementById('master-vol')
-  const disp   = document.getElementById('master-vol-display')
-  if (!slider) return
-
-  function update() {
-    const v = parseFloat(slider.value)
-    const pct = v * 100
-    slider.style.setProperty('--fill', pct + '%')
-    slider.classList.add('filled')
-    if (disp) disp.textContent = Math.round(pct)
-    AudioEngine.setMasterVolume(v)
+// ─── Global header: BPM, master volume, transport ──────────────────────────
+function initGlobalHeader() {
+  // Master volume
+  const volSlider = document.getElementById('master-vol')
+  const volDisp   = document.getElementById('master-vol-display')
+  if (volSlider) {
+    function updateVol() {
+      const v = parseFloat(volSlider.value)
+      const pct = v * 100
+      volSlider.style.setProperty('--fill', pct + '%')
+      volSlider.classList.add('filled')
+      if (volDisp) volDisp.textContent = Math.round(pct)
+      AudioEngine.setMasterVolume(v)
+    }
+    volSlider.addEventListener('input', updateVol)
+    updateVol()
   }
 
-  slider.addEventListener('input', update)
-  // Init fill
-  const pct = parseFloat(slider.value) * 100
-  slider.style.setProperty('--fill', pct + '%')
-  slider.classList.add('filled')
-  if (disp) disp.textContent = Math.round(pct)
-}
+  // BPM
+  const bpmEl = document.getElementById('global-bpm')
+  bpmEl?.addEventListener('change', (e) => {
+    const bpm = parseInt(e.target.value) || 120
+    ProjectStore.dispatch(SetBpm(bpm))
+  })
+  // Store is the source of truth; push into Sequencer's copy and keep the
+  // input in sync (e.g. after project open).
+  ProjectStore.subscribe(() => {
+    const bpm = ProjectStore.getState().bpm
+    if (bpmEl) bpmEl.value = bpm
+    Sequencer.setBPM(bpm)
+  })
 
-// ─── BPM slider ────────────────────────────────────────────────────────────
-function initBPM() {
-  const slider = document.getElementById('bpm-slider')
-  const disp   = document.getElementById('bpm-display')
-  if (!slider) return
-
-  function update() {
-    Sequencer.setBPM(slider.value)
-    if (disp) disp.textContent = slider.value
-    const pct = (slider.value - slider.min) / (slider.max - slider.min) * 100
-    slider.style.setProperty('--fill', pct + '%')
-  }
-
-  slider.classList.add('filled')
-  slider.addEventListener('input', update)
-  update()
+  // Transport — mode-aware: drives Sequencer in synth mode, TimelinePlayer in arrange mode
+  document.getElementById('global-play-btn')?.addEventListener('click', () => {
+    ensureAudio()
+    if (_currentMode === 'arrange') {
+      const state = ProjectStore.getState()
+      TimelinePlayer.play({
+        beat: 0,
+        bpm: state.bpm,
+        tracks: state.tracks,
+        audioStore: AudioStore,
+        mixerEngine: MixerEngine,
+        palettes: Palettes,
+        racks: ProjectStore.getState().racks,
+        rackHandles: [_rackView?.getEngineHandle()].filter(Boolean)
+      })
+    } else {
+      Sequencer.play()
+    }
+  })
+  document.getElementById('global-stop-btn')?.addEventListener('click', () => {
+    if (_currentMode === 'arrange') {
+      TimelinePlayer.stop()
+    } else {
+      Sequencer.stop()
+    }
+  })
 }
 
 // ─── Note events (from Keyboard) ───────────────────────────────────────────
@@ -331,13 +357,6 @@ document.addEventListener('note-off', (e) => {
 
 // ─── Transport buttons ──────────────────────────────────────────────────────
 function initTransport() {
-  document.getElementById('play-btn')?.addEventListener('click', () => {
-    ensureAudio()
-    Sequencer.play()
-  })
-  document.getElementById('stop-btn')?.addEventListener('click', () => {
-    Sequencer.stop()
-  })
   document.getElementById('clear-btn')?.addEventListener('click', () => {
     Sequencer.clear()
   })
@@ -669,49 +688,8 @@ function initMixerParamBus() {
   })
 }
 
-// ─── Arrange transport (play/stop) ──────────────────────────────────────────
-function initArrangeTransport() {
-  // Dedicated arrange toolbar buttons
-  document.getElementById('arr-play-btn')?.addEventListener('click', async () => {
-    await ensureAudio()
-    const state = ProjectStore.getState()
-    // Pre-load any buffers that failed to load when the project was opened
-    if (AudioStore.getProjectDir()) {
-      const loads = []
-      for (const track of state.tracks) {
-        for (const clip of track.clips) {
-          if (clip.type === 'audio' && clip.file && !AudioStore.getBuffer(clip.file)) {
-            loads.push(
-              AudioStore.loadBuffer(clip.file).catch(e => console.warn('[Play] Buffer load failed:', clip.file, e))
-            )
-          }
-        }
-      }
-      if (loads.length) await Promise.all(loads)
-    }
-    TimelinePlayer.play({
-      beat: 0,
-      bpm: state.bpm,
-      tracks: state.tracks,
-      audioStore: AudioStore,
-      mixerEngine: MixerEngine,
-      palettes: Palettes,
-      racks: ProjectStore.getState().racks,
-      rackHandles: [_rackView?.getEngineHandle()].filter(Boolean)
-    })
-    document.getElementById('arr-play-btn').setAttribute('aria-pressed', 'true')
-  })
-
-  document.getElementById('arr-stop-btn')?.addEventListener('click', () => {
-    TimelinePlayer.stop()
-    document.getElementById('arr-play-btn')?.setAttribute('aria-pressed', 'false')
-  })
-
-  document.getElementById('arr-bpm')?.addEventListener('change', (e) => {
-    const bpm = parseInt(e.target.value) || 120
-    ProjectStore.dispatch(SetBpm(bpm))
-  })
-
+// ─── Arrange toolbar (non-transport wiring; transport lives in the global header) ──
+function initArrangeToolbar() {
   // Add Track button in arrange toolbar
   document.getElementById('arr-add-track-btn')?.addEventListener('click', () => {
     ProjectStore.dispatch(AddTrack('audio', 'Track'))
@@ -726,39 +704,6 @@ function initArrangeTransport() {
   document.addEventListener('add-midi-track', () => {
     ProjectStore.dispatch(AddTrack('midi', 'MIDI'))
     syncMixerStrips(ProjectStore.getState())
-  })
-
-  // Keep BPM input in sync with store (e.g. after project open)
-  ProjectStore.subscribe(() => {
-    const bpmEl = document.getElementById('arr-bpm')
-    if (bpmEl) bpmEl.value = ProjectStore.getState().bpm
-  })
-
-  // Synth mode transport
-  document.getElementById('play-btn')?.addEventListener('click', () => {
-    ensureAudio()
-    if (_currentMode === 'arrange') {
-      const state = ProjectStore.getState()
-      TimelinePlayer.play({
-        beat: 0,
-        bpm: state.bpm,
-        tracks: state.tracks,
-        audioStore: AudioStore,
-        mixerEngine: MixerEngine,
-        palettes: Palettes,
-        racks: ProjectStore.getState().racks,
-        rackHandles: [_rackView?.getEngineHandle()].filter(Boolean)
-      })
-    } else {
-      Sequencer.play()
-    }
-  })
-  document.getElementById('stop-btn')?.addEventListener('click', () => {
-    if (_currentMode === 'arrange') {
-      TimelinePlayer.stop()
-    } else {
-      Sequencer.stop()
-    }
   })
 }
 
@@ -995,8 +940,8 @@ function initShortcuts() {
 
   // Transport — Space = play/stop toggle (mode-aware)
   ShortcutManager.register({ key: ' ' }, () => {
-    const playBtn = document.getElementById('play-btn')
-    const stopBtn = document.getElementById('stop-btn')
+    const playBtn = document.getElementById('global-play-btn')
+    const stopBtn = document.getElementById('global-stop-btn')
     if (_isPlaying) {
       stopBtn?.click()
       _isPlaying = false
@@ -1010,9 +955,9 @@ function initShortcuts() {
 
   // Stop always resets
   ShortcutManager.register({ key: ' ', shift: true }, () => {
-    document.getElementById('stop-btn')?.click()
+    document.getElementById('global-stop-btn')?.click()
     _isPlaying = false
-    document.getElementById('play-btn')?.setAttribute('aria-pressed', 'false')
+    document.getElementById('global-play-btn')?.setAttribute('aria-pressed', 'false')
   })
 }
 
@@ -1028,8 +973,7 @@ function boot() {
   if (tr909Container) _tr909View = new Tr909View(tr909Container, { ensureAudio })
 
   renderKnobPanel()
-  initMasterVolume()
-  initBPM()
+  initGlobalHeader()
   initTransport()
   initTabs()
   initRecorder()
@@ -1041,7 +985,7 @@ function boot() {
   initProjectBar()
   initSidebarModes()
   initMixerParamBus()
-  initArrangeTransport()
+  initArrangeToolbar()
   initShortcuts()
   initMidi()
   initPianoRoll()

--- a/src/renderer/js/components/tr909-view.js
+++ b/src/renderer/js/components/tr909-view.js
@@ -2,28 +2,18 @@ import AudioEngine from '../audio-engine.js'
 import Sequencer from '../sequencer.js'
 import { INSTRUMENTS, PARAM_DEFS, makeKitParams, createTr909Voice } from '../drums/tr909-kit.js'
 import { LookaheadScheduler } from '../rack/scheduler.js'
+import ProjectStore, {
+  SetPatternStep,
+  SetBarParam,
+  AddBar,
+  RemoveBar,
+  SetCurrentBar,
+  ClearBar,
+  nextChainPos
+} from '../store/ProjectStore.js'
 
 const STEPS = 16
-
-function makeStep() {
-  return { on: false, velocity: 0.85, accent: false, flam: false }
-}
-
-function makePattern() {
-  return {
-    name: '909 Pattern 1',
-    steps: STEPS,
-    scale: '1/16',
-    shuffle: 0,
-    flam: 0.18,
-    lastStep: 16,
-    totalAccent: 0.45,
-    lanes: Object.fromEntries(INSTRUMENTS.map(inst => [
-      inst.id,
-      Array.from({ length: STEPS }, makeStep)
-    ]))
-  }
-}
+const PATTERN_ID = '909-main'
 
 function formatPct(v) {
   return Math.round(v * 100)
@@ -33,24 +23,102 @@ export class Tr909View {
   constructor(container, options = {}) {
     this.container = container
     this.ensureAudio = options.ensureAudio || (() => AudioEngine.init())
-    this.pattern = makePattern()
+    this.patternId = PATTERN_ID
+
+    // Lazily create the pattern via a harmless dispatch — patternCommand
+    // creates any missing patternId on first dispatch (see store-handoff).
+    if (!ProjectStore.getState().patterns[this.patternId]) {
+      ProjectStore.dispatch(SetCurrentBar(this.patternId, 0))
+    }
+
+    // Cache of patterns[patternId], refreshed in onStoreChange — a dispatch is
+    // the only thing that can change it. Keeps scheduleStep off getState(),
+    // which deep-clones the whole project on every scheduled step.
+    this._patternCache = ProjectStore.getState().patterns[this.patternId]
+
     this.kitParams = makeKitParams()
     this.selectedInstrumentId = 'bd'
     this.showAllLanes = false
+
     this.isPlaying = false
+    this.mode = null // 'bar' | 'chain' | null
     this.schedulerLoop = null
     this.playheadStep = -1
+    this.playingBarIndex = -1 // UI-only: which bar the RAF loop last saw sounding
+    this._activeBarIndex = -1 // audio-only: which bar scheduleStep is reading from
+    this._playingBar = null
+    this.playChainPos = 0
+    this._chainStepsScheduled = 0
     this.rafId = null
+    this._suppressNextRender = false
+    this._viewedBar = 0 // cache of pattern.currentBar, refreshed in render()
+
+    this._lastPatternJSON = null
+    this._unsubscribe = ProjectStore.subscribe(state => this.onStoreChange(state))
 
     this.render()
   }
 
   destroy() {
     this.stop()
+    this._unsubscribe?.()
     this.container.innerHTML = ''
   }
 
+  // ---------------------------------------------------------------------
+  // Store accessors — reads go through _patternCache, kept in sync by the
+  // subscription, so no read path clones the project state.
+  // ---------------------------------------------------------------------
+
+  pattern() {
+    return this._patternCache
+  }
+
+  currentBar() {
+    const pattern = this.pattern()
+    return pattern.bars[pattern.currentBar]
+  }
+
+  // dispatch() always triggers a full re-render via the subscription.
+  // dispatchQuiet() is for high-frequency writes (slider drags) where a
+  // full innerHTML rebuild would break the drag gesture — see updateSliderFills.
+  dispatchQuiet(command) {
+    this._suppressNextRender = true
+    try {
+      ProjectStore.dispatch(command)
+    } finally {
+      this._suppressNextRender = false
+    }
+  }
+
+  // ProjectStore clones the *entire* state tree (JSON.stringify/parse) on
+  // every single dispatch, including unrelated ones (mixer, rack, ...) — so
+  // `patterns[id]` is a fresh object reference after every dispatch, not
+  // just ones that touch it. A literal reference check would therefore
+  // always be "changed" and re-render on every dispatch. Comparing
+  // serialized content instead gives the behaviour the spec actually wants:
+  // re-render only when this pattern's data really changed.
+  // ponytail: JSON.stringify of one pattern per dispatch, cheap enough here —
+  // revisit if bars grow far beyond a handful of steps/lanes.
+  onStoreChange(state) {
+    const pattern = state.patterns[this.patternId]
+    if (!pattern) return
+    this._patternCache = pattern
+    const json = JSON.stringify(pattern)
+    if (json === this._lastPatternJSON) return
+    this._lastPatternJSON = json
+    if (this._suppressNextRender) {
+      this._suppressNextRender = false
+      return
+    }
+    this.render()
+  }
+
   render() {
+    const pattern = this.pattern()
+    const bar = pattern.bars[pattern.currentBar]
+    this._viewedBar = pattern.currentBar
+
     this.container.innerHTML = `
       <div class="tr909-shell">
         <div class="tr909-header">
@@ -59,32 +127,35 @@ export class Tr909View {
             <strong>909</strong>
           </div>
           <div class="tr909-transport" role="toolbar" aria-label="909 transport">
-            <button class="transport-btn play" data-action="play" aria-pressed="false">Play</button>
-            <button class="transport-btn stop" data-action="stop">Stop</button>
+            <button class="transport-btn play" data-action="play-bar" aria-pressed="${this.mode === 'bar'}">▸ Bar</button>
+            <button class="transport-btn play" data-action="play-chain" aria-pressed="${this.mode === 'chain'}">▸ Chain</button>
+            <button class="transport-btn stop" data-action="stop">■ Stop</button>
             <button class="transport-btn clear" data-action="clear">Clear</button>
             <button class="transport-btn" data-action="randomize">Random</button>
           </div>
-          <div class="tr909-pattern">
-            <label class="knob-label" for="tr909-pattern-slot">Pattern</label>
-            <select id="tr909-pattern-slot" class="knob-select" aria-label="909 pattern slot">
-              <option>A1</option><option>A2</option><option>A3</option><option>A4</option>
-            </select>
+          <div class="tr909-barstrip" role="toolbar" aria-label="Pattern bars">
+            <span class="tr909-barstrip-label">BARS</span>
+            <div class="tr909-bar-buttons">
+              ${pattern.bars.map((b, i) => this.renderBarButton(pattern, i)).join('')}
+            </div>
+            <button class="tr909-bar-add" data-action="add-bar" aria-label="Add bar" title="Add empty bar">+</button>
+            <button class="tr909-bar-copy" data-action="copy-bar" title="Copy current bar into a new bar">⧉ Copy Bar</button>
           </div>
         </div>
 
         <div class="tr909-global">
-          ${this.renderGlobalSlider('shuffle', 'Shuffle', 0, 1, 0.01)}
-          ${this.renderGlobalSlider('flam', 'Flam', 0, 1, 0.01)}
-          ${this.renderGlobalSlider('totalAccent', 'Accent', 0, 1, 0.01)}
+          ${this.renderGlobalSlider(bar, 'shuffle', 'Shuffle', 0, 1, 0.01)}
+          ${this.renderGlobalSlider(bar, 'flam', 'Flam', 0, 1, 0.01)}
+          ${this.renderGlobalSlider(bar, 'totalAccent', 'Accent', 0, 1, 0.01)}
           <label class="tr909-control">
             <span>Last</span>
-            <input type="number" min="1" max="16" value="${this.pattern.lastStep}" data-global="lastStep" aria-label="Last step">
+            <input type="number" min="1" max="16" value="${bar.lastStep}" data-global="lastStep" aria-label="Last step">
           </label>
           <label class="tr909-control">
             <span>Scale</span>
             <select data-global="scale" aria-label="Step scale">
-              <option value="1/16"${this.pattern.scale === '1/16' ? ' selected' : ''}>1/16</option>
-              <option value="1/32"${this.pattern.scale === '1/32' ? ' selected' : ''}>1/32</option>
+              <option value="1/16"${bar.scale === '1/16' ? ' selected' : ''}>1/16</option>
+              <option value="1/32"${bar.scale === '1/32' ? ' selected' : ''}>1/32</option>
             </select>
           </label>
           <button class="tr909-toggle${this.showAllLanes ? ' active' : ''}" data-action="toggle-lanes" aria-pressed="${this.showAllLanes}">All Lanes</button>
@@ -100,16 +171,16 @@ export class Tr909View {
               <button class="tr909-audition" data-action="audition">Trig</button>
             </div>
             <div class="tr909-steps" role="grid" aria-label="Selected instrument steps">
-              ${Array.from({ length: STEPS }, (_, i) => this.renderStepButton(this.selectedInstrumentId, i)).join('')}
+              ${Array.from({ length: STEPS }, (_, i) => this.renderStepButton(bar, this.selectedInstrumentId, i)).join('')}
             </div>
             <div class="tr909-sub-lanes">
               <div class="tr909-sub-label">Accent</div>
-              <div class="tr909-mini-steps">${Array.from({ length: STEPS }, (_, i) => this.renderMiniButton('accent', i)).join('')}</div>
+              <div class="tr909-mini-steps">${Array.from({ length: STEPS }, (_, i) => this.renderMiniButton(bar, 'accent', i)).join('')}</div>
               <div class="tr909-sub-label">Flam</div>
-              <div class="tr909-mini-steps">${Array.from({ length: STEPS }, (_, i) => this.renderMiniButton('flam', i)).join('')}</div>
+              <div class="tr909-mini-steps">${Array.from({ length: STEPS }, (_, i) => this.renderMiniButton(bar, 'flam', i)).join('')}</div>
             </div>
             <div class="tr909-all-lanes"${this.showAllLanes ? '' : ' hidden'}>
-              ${INSTRUMENTS.map(inst => this.renderAllLane(inst)).join('')}
+              ${INSTRUMENTS.map(inst => this.renderAllLane(bar, inst)).join('')}
             </div>
           </div>
           <div class="tr909-params">
@@ -121,11 +192,24 @@ export class Tr909View {
 
     this.bindEvents()
     this.updateSliderFills()
+    this.updateTransportButtons()
     this.updatePlayhead()
   }
 
-  renderGlobalSlider(key, label, min, max, step) {
-    const value = this.pattern[key]
+  renderBarButton(pattern, index) {
+    const selected = index === pattern.currentBar
+    const playing = this.isPlaying && index === this.playingBarIndex
+    const canRemove = pattern.bars.length > 1
+    return `
+      <span class="tr909-bar-btn-wrap">
+        <button class="tr909-bar-btn${selected ? ' selected' : ''}${playing ? ' bar-playing' : ''}" data-bar="${index}" aria-pressed="${selected}"${playing ? ' aria-current="true"' : ''}>${index + 1}</button>
+        ${canRemove ? `<button class="tr909-bar-remove" data-action="remove-bar" data-bar="${index}" aria-label="Remove bar ${index + 1}" title="Remove bar">×</button>` : ''}
+      </span>
+    `
+  }
+
+  renderGlobalSlider(bar, key, label, min, max, step) {
+    const value = bar[key]
     return `
       <label class="tr909-control">
         <span>${label}</span>
@@ -146,8 +230,8 @@ export class Tr909View {
     `
   }
 
-  renderStepButton(laneId, index) {
-    const step = this.pattern.lanes[laneId][index]
+  renderStepButton(bar, laneId, index) {
+    const step = bar.lanes[laneId][index]
     const beat = index % 4 === 0 ? ' beat' : ''
     return `
       <button class="tr909-step${step.on ? ' on' : ''}${beat}" data-step="${index}" aria-pressed="${step.on}">
@@ -156,24 +240,24 @@ export class Tr909View {
     `
   }
 
-  renderMiniButton(key, index) {
-    const step = this.pattern.lanes[this.selectedInstrumentId][index]
+  renderMiniButton(bar, key, index) {
+    const step = bar.lanes[this.selectedInstrumentId][index]
     return `<button class="tr909-mini${step[key] ? ' on' : ''}" data-sub="${key}" data-step="${index}" aria-pressed="${step[key]}"></button>`
   }
 
-  renderAllLane(inst) {
+  renderAllLane(bar, inst) {
     return `
       <div class="tr909-grid-row" style="--inst-color:${inst.color}">
         <button class="tr909-grid-label" data-inst="${inst.id}">${inst.label}</button>
         <div class="tr909-grid-steps">
-          ${Array.from({ length: STEPS }, (_, i) => this.renderGridCell(inst.id, i)).join('')}
+          ${Array.from({ length: STEPS }, (_, i) => this.renderGridCell(bar, inst.id, i)).join('')}
         </div>
       </div>
     `
   }
 
-  renderGridCell(laneId, index) {
-    const step = this.pattern.lanes[laneId][index]
+  renderGridCell(bar, laneId, index) {
+    const step = bar.lanes[laneId][index]
     return `<button class="tr909-grid-cell${step.on ? ' on' : ''}" data-grid-lane="${laneId}" data-step="${index}" aria-pressed="${step.on}"></button>`
   }
 
@@ -193,15 +277,37 @@ export class Tr909View {
   }
 
   bindEvents() {
-    this.container.querySelector('[data-action="play"]')?.addEventListener('click', () => this.play())
+    this.container.querySelector('[data-action="play-bar"]')?.addEventListener('click', () => this.playBar())
+    this.container.querySelector('[data-action="play-chain"]')?.addEventListener('click', () => this.playChain())
     this.container.querySelector('[data-action="stop"]')?.addEventListener('click', () => this.stop())
-    this.container.querySelector('[data-action="clear"]')?.addEventListener('click', () => this.clearPattern())
+    this.container.querySelector('[data-action="clear"]')?.addEventListener('click', () => this.clearBar())
     this.container.querySelector('[data-action="randomize"]')?.addEventListener('click', () => this.randomize())
     this.container.querySelector('[data-action="toggle-lanes"]')?.addEventListener('click', () => {
       this.showAllLanes = !this.showAllLanes
       this.render()
     })
     this.container.querySelector('[data-action="audition"]')?.addEventListener('click', () => this.trigger(this.selectedInstrumentId, 0.9))
+
+    this.container.querySelectorAll('.tr909-bar-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        ProjectStore.dispatch(SetCurrentBar(this.patternId, Number(btn.dataset.bar)))
+      })
+    })
+    this.container.querySelectorAll('.tr909-bar-remove').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation()
+        ProjectStore.dispatch(RemoveBar(this.patternId, Number(btn.dataset.bar)))
+      })
+    })
+    this.container.querySelector('[data-action="add-bar"]')?.addEventListener('click', () => {
+      ProjectStore.dispatch(AddBar(this.patternId, { copyFrom: null }))
+    })
+    this.container.querySelector('[data-action="copy-bar"]')?.addEventListener('click', () => {
+      const barIndex = this.pattern().currentBar
+      this.dispatchQuiet(AddBar(this.patternId, { copyFrom: barIndex }))
+      const newIndex = this.pattern().bars.length - 1
+      ProjectStore.dispatch(SetCurrentBar(this.patternId, newIndex))
+    })
 
     this.container.querySelectorAll('[data-inst]').forEach(btn => {
       btn.addEventListener('click', () => {
@@ -213,36 +319,34 @@ export class Tr909View {
     this.container.querySelectorAll('[data-step]:not([data-sub]):not([data-grid-lane])').forEach(btn => {
       btn.addEventListener('click', () => {
         this.toggleStep(this.selectedInstrumentId, Number(btn.dataset.step), 'on')
-        this.render()
       })
     })
 
     this.container.querySelectorAll('[data-sub]').forEach(btn => {
       btn.addEventListener('click', () => {
         this.toggleStep(this.selectedInstrumentId, Number(btn.dataset.step), btn.dataset.sub)
-        this.render()
       })
     })
 
     this.container.querySelectorAll('[data-grid-lane]').forEach(btn => {
       btn.addEventListener('click', () => {
         const laneId = btn.dataset.gridLane
-        this.toggleStep(laneId, Number(btn.dataset.step), 'on')
         this.selectedInstrumentId = laneId
-        this.render()
+        this.toggleStep(laneId, Number(btn.dataset.step), 'on')
       })
     })
 
     this.container.querySelectorAll('[data-global]').forEach(input => {
       input.addEventListener('input', () => {
         const key = input.dataset.global
-        if (key === 'lastStep') {
-          this.pattern.lastStep = Math.max(1, Math.min(16, Number(input.value) || 16))
-        } else if (key === 'scale') {
-          this.pattern.scale = input.value
-        } else {
-          this.pattern[key] = Number(input.value)
-        }
+        let value
+        if (key === 'lastStep') value = Math.max(1, Math.min(16, Number(input.value) || 16))
+        else if (key === 'scale') value = input.value
+        else value = Number(input.value)
+        // Quiet dispatch: persists the value but skips the auto full-rebuild
+        // that dispatch() would otherwise trigger — a slider mid-drag can't
+        // survive its own DOM node being replaced under the pointer.
+        this.dispatchQuiet(SetBarParam(this.patternId, this.pattern().currentBar, key, value))
         this.updateSliderFills()
       })
     })
@@ -262,30 +366,39 @@ export class Tr909View {
   }
 
   toggleStep(laneId, stepIndex, key) {
-    const step = this.pattern.lanes[laneId][stepIndex]
-    step[key] = !step[key]
-    if ((key === 'accent' || key === 'flam') && step[key]) step.on = true
+    const bar = this.currentBar()
+    const step = bar.lanes[laneId][stepIndex]
+    const patch = { [key]: !step[key] }
+    if ((key === 'accent' || key === 'flam') && patch[key]) patch.on = true
+    ProjectStore.dispatch(SetPatternStep(this.patternId, this.pattern().currentBar, laneId, stepIndex, patch))
   }
 
-  clearPattern() {
-    Object.values(this.pattern.lanes).forEach(lane => lane.forEach(step => {
-      step.on = false; step.accent = false; step.flam = false; step.velocity = 0.85
-    }))
-    this.render()
+  clearBar() {
+    ProjectStore.dispatch(ClearBar(this.patternId, this.pattern().currentBar))
   }
 
   randomize() {
     const density = { bd: 0.28, sd: 0.18, lt: 0.08, mt: 0.08, ht: 0.08, rs: 0.06, cp: 0.09, ch: 0.44, oh: 0.12, cr: 0.05, rd: 0.08 }
+    const barIndex = this.pattern().currentBar
+    const patches = []
     INSTRUMENTS.forEach(inst => {
-      this.pattern.lanes[inst.id].forEach((step, i) => {
+      for (let i = 0; i < STEPS; i++) {
         const beatBias = (inst.id === 'bd' && i % 4 === 0) || (inst.id === 'sd' && i % 8 === 4) ? 0.25 : 0
-        step.on = Math.random() < (density[inst.id] + beatBias)
-        step.accent = step.on && Math.random() < 0.12
-        step.flam = step.on && ['sd', 'cp', 'rs'].includes(inst.id) && Math.random() < 0.08
-        step.velocity = 0.72 + Math.random() * 0.25
-      })
+        const on = Math.random() < (density[inst.id] + beatBias)
+        patches.push([inst.id, i, {
+          on,
+          accent: on && Math.random() < 0.12,
+          flam: on && ['sd', 'cp', 'rs'].includes(inst.id) && Math.random() < 0.08,
+          velocity: 0.72 + Math.random() * 0.25
+        }])
+      }
     })
-    this.render()
+    // One dispatch per step, but only the last one triggers a re-render.
+    patches.forEach(([instId, i, patch], idx) => {
+      const command = SetPatternStep(this.patternId, barIndex, instId, i, patch)
+      if (idx < patches.length - 1) this.dispatchQuiet(command)
+      else ProjectStore.dispatch(command)
+    })
   }
 
   async trigger(instrumentId, velocity, event = {}, time = null) {
@@ -302,21 +415,50 @@ export class Tr909View {
     )
   }
 
-  async play() {
-    if (this.isPlaying) return
+  async playBar() {
+    if (this.isPlaying) this.stop()
     await this.ensureAudio()
     const ctx = AudioEngine.getContext()
     if (!ctx) return
+    const pattern = this.pattern()
     this.isPlaying = true
+    this.mode = 'bar'
+    this._activeBarIndex = pattern.currentBar
+    const bar = pattern.bars[this._activeBarIndex]
     this.schedulerLoop = new LookaheadScheduler({
       getCurrentTime: () => AudioEngine.getContext()?.currentTime,
       schedule: (step, time) => this.scheduleStep(step, time),
       advance: () => this.stepDuration(),
-      steps: this.pattern.lastStep
+      steps: bar.lastStep
     })
     this.schedulerLoop.stepTimes = new Array(STEPS).fill(-Infinity)
-    this.container.querySelector('[data-action="play"]')?.classList.add('active-btn')
-    this.container.querySelector('[data-action="play"]')?.setAttribute('aria-pressed', 'true')
+    this.schedulerLoop.barAtStepTime = new Array(STEPS).fill(-1)
+    this.updateTransportButtons()
+    this.schedulerLoop.start({ time: ctx.currentTime + 0.05 })
+    this.startPlayhead()
+  }
+
+  async playChain() {
+    if (this.isPlaying) this.stop()
+    await this.ensureAudio()
+    const ctx = AudioEngine.getContext()
+    if (!ctx) return
+    const pattern = this.pattern()
+    this.isPlaying = true
+    this.mode = 'chain'
+    this.playChainPos = 0
+    this._chainStepsScheduled = 0
+    this._activeBarIndex = pattern.chain[0] ?? 0
+    const bar = pattern.bars[this._activeBarIndex] || pattern.bars[0]
+    this.schedulerLoop = new LookaheadScheduler({
+      getCurrentTime: () => AudioEngine.getContext()?.currentTime,
+      schedule: (step, time) => this.scheduleStep(step, time),
+      advance: () => this.stepDuration(),
+      steps: bar.lastStep
+    })
+    this.schedulerLoop.stepTimes = new Array(STEPS).fill(-Infinity)
+    this.schedulerLoop.barAtStepTime = new Array(STEPS).fill(-1)
+    this.updateTransportButtons()
     this.schedulerLoop.start({ time: ctx.currentTime + 0.05 })
     this.startPlayhead()
   }
@@ -324,22 +466,47 @@ export class Tr909View {
   stop() {
     if (!this.isPlaying) return
     this.isPlaying = false
+    this.mode = null
     this.schedulerLoop?.stop()
     cancelAnimationFrame(this.rafId)
     this.playheadStep = -1
-    this.container.querySelector('[data-action="play"]')?.classList.remove('active-btn')
-    this.container.querySelector('[data-action="play"]')?.setAttribute('aria-pressed', 'false')
+    this.playingBarIndex = -1
+    this._activeBarIndex = -1
+    this._playingBar = null
+    this.updateTransportButtons()
     this.updatePlayhead()
   }
 
+  // stepIndex/time come straight from LookaheadScheduler.tick() — stepIndex
+  // is the step *about to be scheduled*, called before tick() advances
+  // `this.step`. In chain mode, resolving the next bar and reassigning
+  // schedulerLoop.steps must happen here, at stepIndex === 0, not at the
+  // outgoing bar's last step — tick()'s wrap `(lastStep-1+1) % steps` needs
+  // the *outgoing* bar's lastStep to land on 0.
   scheduleStep(stepIndex, time) {
+    const pattern = this.pattern()
+
+    if (this.mode === 'chain' && stepIndex === 0) {
+      if (this._chainStepsScheduled > 0) {
+        this.playChainPos = nextChainPos(this.playChainPos, pattern.chain.length)
+      }
+      this._chainStepsScheduled++
+      this._activeBarIndex = pattern.chain[this.playChainPos] ?? 0
+      const nextBar = pattern.bars[this._activeBarIndex] || pattern.bars[0]
+      if (this.schedulerLoop) this.schedulerLoop.steps = nextBar.lastStep
+    }
+
+    const bar = pattern.bars[this._activeBarIndex] || pattern.bars[0]
+    this._playingBar = bar
+    if (this.schedulerLoop) this.schedulerLoop.barAtStepTime[stepIndex] = this._activeBarIndex
+
     const stepDur = this.stepDuration()
-    const shuffleOffset = this.pattern.shuffle * stepDur * 0.45
+    const shuffleOffset = bar.shuffle * stepDur * 0.45
     const shuffledTime = stepIndex % 2 === 1 ? time + shuffleOffset : time
     INSTRUMENTS.forEach(inst => {
-      const step = this.pattern.lanes[inst.id][stepIndex]
+      const step = bar.lanes[inst.id][stepIndex]
       if (!step.on) return
-      const accentAmount = step.accent ? this.pattern.totalAccent : 0
+      const accentAmount = step.accent ? bar.totalAccent : 0
       const event = {
         velocity: Math.min(1, step.velocity + accentAmount * 0.25),
         accent: step.accent,
@@ -353,16 +520,17 @@ export class Tr909View {
           inst.id,
           this.kitParams,
           { ...event, velocity: event.velocity * 0.62 },
-          shuffledTime + 0.012 + this.pattern.flam * 0.055
+          shuffledTime + 0.012 + bar.flam * 0.055
         )
       }
     })
   }
 
   stepDuration() {
+    const bar = this._playingBar || this.currentBar()
     const bpm = Sequencer.getBPM ? Sequencer.getBPM() : 120
     const sixteenth = (60 / bpm) / 4
-    return this.pattern.scale === '1/32' ? sixteenth / 2 : sixteenth
+    return bar.scale === '1/32' ? sixteenth / 2 : sixteenth
   }
 
   startPlayhead() {
@@ -373,13 +541,18 @@ export class Tr909View {
         let bestStep = -1
         let bestTime = -Infinity
         for (let i = 0; i < STEPS; i++) {
-          if (this.schedulerLoop?.stepTimes[i] <= ctx.currentTime && this.schedulerLoop.stepTimes[i] > bestTime) {
+          const t = this.schedulerLoop?.stepTimes[i]
+          if (t !== undefined && t <= ctx.currentTime && t > bestTime) {
             bestStep = i
-            bestTime = this.schedulerLoop.stepTimes[i]
+            bestTime = t
           }
         }
         if (bestStep !== this.playheadStep) {
           this.playheadStep = bestStep
+          // Read which bar is sounding out of barAtStepTime — recorded at
+          // schedule time. The RAF loop only paints; it never advances
+          // playback itself, audio runs ahead of the display.
+          this.playingBarIndex = bestStep >= 0 ? (this.schedulerLoop?.barAtStepTime[bestStep] ?? -1) : -1
           this.updatePlayhead()
         }
       }
@@ -389,9 +562,29 @@ export class Tr909View {
   }
 
   updatePlayhead() {
+    const showStepGlow = this.isPlaying && this.playingBarIndex === this._viewedBar
     this.container.querySelectorAll('[data-step]').forEach(el => {
-      el.classList.toggle('playing', Number(el.dataset.step) === this.playheadStep)
+      el.classList.toggle('playing', showStepGlow && Number(el.dataset.step) === this.playheadStep)
     })
+    this.container.querySelectorAll('.tr909-bar-btn').forEach(el => {
+      const isPlayingBar = this.isPlaying && Number(el.dataset.bar) === this.playingBarIndex
+      el.classList.toggle('bar-playing', isPlayingBar)
+      if (isPlayingBar) el.setAttribute('aria-current', 'true')
+      else el.removeAttribute('aria-current')
+    })
+  }
+
+  updateTransportButtons() {
+    const barBtn = this.container.querySelector('[data-action="play-bar"]')
+    const chainBtn = this.container.querySelector('[data-action="play-chain"]')
+    if (barBtn) {
+      barBtn.classList.toggle('active-btn', this.mode === 'bar')
+      barBtn.setAttribute('aria-pressed', String(this.mode === 'bar'))
+    }
+    if (chainBtn) {
+      chainBtn.classList.toggle('active-btn', this.mode === 'chain')
+      chainBtn.setAttribute('aria-pressed', String(this.mode === 'chain'))
+    }
   }
 
   updateSliderFills() {

--- a/src/renderer/js/store/ProjectStore.js
+++ b/src/renderer/js/store/ProjectStore.js
@@ -1,6 +1,8 @@
 // ProjectStore.js — Central state store for the DAW
 // Implements a command pattern for undo/redo.
 
+import { INSTRUMENTS } from '../drums/tr909-kit.js'
+
 // ---------------------------------------------------------------------------
 // ID generation (no crypto dependency)
 // ---------------------------------------------------------------------------
@@ -10,7 +12,7 @@ function genId(prefix = 'id') { return `${prefix}-${++_idCounter}-${Date.now()}`
 // ---------------------------------------------------------------------------
 // Default state schema
 // ---------------------------------------------------------------------------
-export const CURRENT_VERSION = 2
+export const CURRENT_VERSION = 3
 
 export const DEFAULT_STATE = {
   version: CURRENT_VERSION,
@@ -38,6 +40,10 @@ export function migrate(projectJson) {
   if ((next.version ?? 1) < 2) {
     if (!next.racks) next.racks = {}
     next.version = 2
+  }
+  if ((next.version ?? 1) < 3) {
+    if (!next.patterns) next.patterns = {}
+    next.version = 3
   }
   for (const track of next.tracks || []) {
     if (track.type === 'midi' && !track.instrument) {
@@ -618,6 +624,138 @@ export function LoadRackPatch(rackId, rackData) {
     },
     undo(state) { return state }
   }
+}
+
+// ---------------------------------------------------------------------------
+// TR-909 pattern bars (specs/tr-909-pattern-bars.md)
+//
+// state.patterns[patternId] = { id, name, currentBar, chain, bars[] }
+// Each bar holds its own scale/shuffle/flam/lastStep/totalAccent and a
+// lanes map keyed by INSTRUMENTS id. `chain` is a list of indices into
+// `bars`, so a bar can repeat without duplicating its lanes.
+// ---------------------------------------------------------------------------
+
+const BAR_PARAM_KEYS = new Set(['scale', 'shuffle', 'flam', 'lastStep', 'totalAccent'])
+
+function makeStep() {
+  return { on: false, velocity: 0.85, accent: false, flam: false }
+}
+
+export function makeBar() {
+  return {
+    id: genId('bar'),
+    scale: '1/16',
+    shuffle: 0,
+    flam: 0.18,
+    lastStep: 16,
+    totalAccent: 0.45,
+    lanes: Object.fromEntries(INSTRUMENTS.map(inst => [
+      inst.id,
+      Array.from({ length: 16 }, makeStep)
+    ]))
+  }
+}
+
+export function makePattern909(id) {
+  return {
+    id,
+    name: '909',
+    currentBar: 0,
+    chain: [0],
+    bars: [makeBar()]
+  }
+}
+
+// Chain cursor wraparound — pure, used by playback and by tests.
+export function nextChainPos(pos, chainLength) {
+  if (chainLength <= 0) return 0
+  return (pos + 1) % chainLength
+}
+
+// Clone state, ensure the pattern exists (creating it via makePattern909 if
+// absent), mutate it, return the new state. Mirrors rackCommand above.
+function patternCommand(label, patternId, mutate) {
+  return {
+    label,
+    execute(state) {
+      const next = JSON.parse(JSON.stringify(state))
+      if (!next.patterns) next.patterns = {}
+      if (!next.patterns[patternId]) next.patterns[patternId] = makePattern909(patternId)
+      mutate(next.patterns[patternId], next)
+      return next
+    },
+    undo(state) { return state }
+  }
+}
+
+export function SetPatternStep(patternId, barIndex, instrumentId, stepIndex, patch) {
+  return patternCommand('Set step', patternId, pattern => {
+    const bar = pattern.bars[barIndex]
+    if (!bar) return
+    const lane = bar.lanes[instrumentId]
+    if (!lane || !lane[stepIndex]) return
+    Object.assign(lane[stepIndex], patch)
+  })
+}
+
+export function SetBarParam(patternId, barIndex, key, value) {
+  return patternCommand('Set bar param', patternId, pattern => {
+    if (!BAR_PARAM_KEYS.has(key)) return
+    const bar = pattern.bars[barIndex]
+    if (!bar) return
+    bar[key] = value
+  })
+}
+
+export function AddBar(patternId, { copyFrom = null } = {}) {
+  return patternCommand('Add bar', patternId, pattern => {
+    let bar
+    if (copyFrom !== null && pattern.bars[copyFrom]) {
+      bar = JSON.parse(JSON.stringify(pattern.bars[copyFrom]))
+      bar.id = genId('bar')
+    } else {
+      bar = makeBar()
+    }
+    pattern.bars.push(bar)
+    pattern.chain.push(pattern.bars.length - 1)
+  })
+}
+
+export function RemoveBar(patternId, barIndex) {
+  return patternCommand('Remove bar', patternId, pattern => {
+    if (pattern.bars.length <= 1) return
+    if (barIndex < 0 || barIndex >= pattern.bars.length) return
+    pattern.bars.splice(barIndex, 1)
+    pattern.chain = pattern.chain
+      .filter(i => i !== barIndex)
+      .map(i => (i > barIndex ? i - 1 : i))
+    if (!pattern.chain.length) pattern.chain = [0]
+    if (pattern.currentBar >= pattern.bars.length) pattern.currentBar = pattern.bars.length - 1
+    else if (pattern.currentBar > barIndex) pattern.currentBar -= 1
+  })
+}
+
+export function SetCurrentBar(patternId, barIndex) {
+  return patternCommand('Set current bar', patternId, pattern => {
+    if (barIndex < 0 || barIndex >= pattern.bars.length) return
+    pattern.currentBar = barIndex
+  })
+}
+
+export function SetChain(patternId, chain) {
+  return patternCommand('Set chain', patternId, pattern => {
+    pattern.chain = [...chain]
+  })
+}
+
+export function ClearBar(patternId, barIndex) {
+  return patternCommand('Clear bar', patternId, pattern => {
+    const bar = pattern.bars[barIndex]
+    if (!bar) return
+    for (const instId of Object.keys(bar.lanes)) {
+      bar.lanes[instId] = Array.from({ length: bar.lanes[instId].length }, makeStep)
+    }
+  })
 }
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -467,7 +467,6 @@ input[type=range]::-moz-range-thumb {
 
 /* Master vol slider (wider) */
 #master-vol { width: 70px; }
-#bpm-slider  { width: 120px; }
 
 /* ─── Keyboard Section ─────────────────────────────────────────────────────── */
 #keyboard-section {
@@ -1094,12 +1093,6 @@ input[type=range]::-moz-range-thumb {
 .transport-btn.stop:hover { border-color: #ff4444; color: #ff4444; }
 .transport-btn.clear:hover { border-color: var(--accent2); color: var(--accent2); }
 
-.bpm-group {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
 /* ─── Scrollbars ───────────────────────────────────────────────────────────── */
 ::-webkit-scrollbar { width: 6px; height: 6px; }
 ::-webkit-scrollbar-track { background: var(--bg); }
@@ -1108,6 +1101,35 @@ input[type=range]::-moz-range-thumb {
 
 /* ─── Utility ──────────────────────────────────────────────────────────────── */
 button { font-family: var(--font-mono); }
+
+/* ─── Global Header (BPM, master volume, transport) ─────────────────────── */
+#global-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg2);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+#global-bpm {
+  width: 52px;
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 3px 6px;
+  font-family: inherit;
+  font-size: 12px;
+  text-align: center;
+  border-radius: 3px;
+}
+#header-view-slot {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+}
 
 /* ─── Phase 1: Project Bar ────────────────────────────────────────────────── */
 #project-bar {
@@ -1165,17 +1187,6 @@ button { font-family: var(--font-mono); }
 #arrange-toolbar .transport-btn {
   padding: 4px 12px;
   font-size: 11px;
-}
-#arr-bpm {
-  width: 52px;
-  background: var(--bg4);
-  border: 1px solid var(--border);
-  color: var(--text);
-  padding: 3px 6px;
-  font-family: inherit;
-  font-size: 12px;
-  text-align: center;
-  border-radius: 3px;
 }
 #arrangement-container {
   flex: 1;

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -673,6 +673,86 @@ input[type=range]::-moz-range-thumb {
   padding: 6px 10px;
 }
 
+.tr909-barstrip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.tr909-barstrip-label {
+  color: var(--text-dim);
+  font-size: 10px;
+  letter-spacing: 1px;
+}
+.tr909-bar-buttons {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.tr909-bar-btn-wrap {
+  position: relative;
+  display: inline-flex;
+}
+.tr909-bar-btn {
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 11px;
+  min-width: 26px;
+  height: 26px;
+  padding: 0 6px;
+  cursor: pointer;
+  border-radius: 3px;
+}
+.tr909-bar-btn:hover { border-color: var(--accent); color: var(--accent); }
+/* Selected — persistent outline, the bar the editor is showing. */
+.tr909-bar-btn.selected {
+  border-color: #f05a28;
+  color: #f05a28;
+}
+/* Playing — bright animated fill, the bar currently sounding in chain mode.
+   Composes with .selected: a bar can be both at once. */
+.tr909-bar-btn.bar-playing {
+  background: #f05a28;
+  color: #050505;
+  box-shadow: 0 0 10px #f05a2899;
+  animation: tr909-bar-pulse 0.5s ease-in-out infinite alternate;
+}
+@keyframes tr909-bar-pulse {
+  from { box-shadow: 0 0 6px #f05a2866; }
+  to   { box-shadow: 0 0 14px #f05a28cc; }
+}
+.tr909-bar-remove {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 14px;
+  height: 14px;
+  line-height: 12px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--bg2);
+  color: var(--text-dim);
+  font-size: 10px;
+  cursor: pointer;
+}
+.tr909-bar-remove:hover { border-color: #ff4444; color: #ff4444; }
+.tr909-bar-add,
+.tr909-bar-copy {
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 11px;
+  height: 26px;
+  padding: 0 10px;
+  cursor: pointer;
+}
+.tr909-bar-add:hover,
+.tr909-bar-copy:hover { border-color: var(--accent); color: var(--accent); }
+
 .tr909-pattern,
 .tr909-control,
 .tr909-param {

--- a/tests/rack-store.test.js
+++ b/tests/rack-store.test.js
@@ -26,10 +26,10 @@ describe('rack store', () => {
   beforeEach(() => ProjectStore.reset())
 
   describe('schema', () => {
-    it('defaults to an empty racks map at version 2', () => {
+    it('defaults to an empty racks map at the current version', () => {
       expect(ProjectStore.getState().racks).toEqual({})
       expect(DEFAULT_STATE.version).toBe(CURRENT_VERSION)
-      expect(CURRENT_VERSION).toBe(2)
+      expect(CURRENT_VERSION).toBe(3)
     })
   })
 
@@ -195,7 +195,7 @@ describe('rack store', () => {
     it('adds an empty racks map to a v1 project', () => {
       const old = { version: 1, bpm: 128, tracks: [], mixer: { channels: [], master: {} }, patterns: {} }
       const next = migrate(old)
-      expect(next.version).toBe(2)
+      expect(next.version).toBe(CURRENT_VERSION)
       expect(next.racks).toEqual({})
       expect(next.bpm).toBe(128)
     })
@@ -204,9 +204,12 @@ describe('rack store', () => {
       expect(migrate({ bpm: 90 }).racks).toEqual({})
     })
 
-    it('leaves a v2 project untouched', () => {
+    it('leaves a v2 project\'s racks untouched, adding patterns and bumping version', () => {
       const v2 = { version: 2, racks: { 'rack-1': { id: 'rack-1', modules: [], cables: [] } } }
-      expect(migrate(v2)).toEqual(v2)
+      const next = migrate(v2)
+      expect(next.version).toBe(CURRENT_VERSION)
+      expect(next.racks).toEqual(v2.racks)
+      expect(next.patterns).toEqual({})
     })
 
     it('does not mutate its input', () => {
@@ -218,7 +221,7 @@ describe('rack store', () => {
     it('runs on load()', () => {
       ProjectStore.load({ version: 1, bpm: 100, tracks: [], mixer: { channels: [] }, patterns: {} })
       const state = ProjectStore.getState()
-      expect(state.version).toBe(2)
+      expect(state.version).toBe(CURRENT_VERSION)
       expect(state.racks).toEqual({})
     })
   })

--- a/tests/tr909-patterns.test.js
+++ b/tests/tr909-patterns.test.js
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import ProjectStore, {
+  SetPatternStep, SetBarParam, AddBar, RemoveBar, SetCurrentBar, SetChain, ClearBar,
+  nextChainPos, makeBar, makePattern909,
+  migrate, DEFAULT_STATE, CURRENT_VERSION
+} from '../src/renderer/js/store/ProjectStore.js'
+import { INSTRUMENTS } from '../src/renderer/js/drums/tr909-kit.js'
+
+const PATTERN_ID = '909-main'
+
+function pattern() {
+  return ProjectStore.getState().patterns[PATTERN_ID]
+}
+
+describe('tr-909 pattern bars', () => {
+  beforeEach(() => ProjectStore.reset())
+
+  describe('schema', () => {
+    it('defaults to an empty patterns map at version 3', () => {
+      expect(ProjectStore.getState().patterns).toEqual({})
+      expect(DEFAULT_STATE.version).toBe(CURRENT_VERSION)
+      expect(CURRENT_VERSION).toBe(3)
+    })
+  })
+
+  describe('makeBar / makePattern909', () => {
+    it('makeBar has one lane per INSTRUMENTS entry, 16 steps, all off', () => {
+      const bar = makeBar()
+      expect(bar.scale).toBe('1/16')
+      expect(bar.lastStep).toBe(16)
+      expect(Object.keys(bar.lanes).sort()).toEqual(INSTRUMENTS.map(i => i.id).sort())
+      for (const inst of INSTRUMENTS) {
+        expect(bar.lanes[inst.id]).toHaveLength(16)
+        expect(bar.lanes[inst.id].every(s => s.on === false)).toBe(true)
+      }
+    })
+
+    it('makePattern909 starts with one bar and a single-entry chain', () => {
+      const p = makePattern909(PATTERN_ID)
+      expect(p.id).toBe(PATTERN_ID)
+      expect(p.currentBar).toBe(0)
+      expect(p.chain).toEqual([0])
+      expect(p.bars).toHaveLength(1)
+    })
+  })
+
+  describe('SetPatternStep', () => {
+    it('changes only the addressed step', () => {
+      ProjectStore.dispatch(SetPatternStep(PATTERN_ID, 0, 'bd', 3, { on: true, accent: true }))
+      const bar = pattern().bars[0]
+      expect(bar.lanes.bd[3]).toMatchObject({ on: true, accent: true })
+      expect(bar.lanes.bd[2].on).toBe(false)
+      expect(bar.lanes.bd[4].on).toBe(false)
+      expect(bar.lanes.sd[3].on).toBe(false)
+    })
+
+    it('is a no-op for an out-of-range step or bar', () => {
+      ProjectStore.dispatch(SetPatternStep(PATTERN_ID, 0, 'bd', 99, { on: true }))
+      ProjectStore.dispatch(SetPatternStep(PATTERN_ID, 5, 'bd', 0, { on: true }))
+      expect(pattern().bars[0].lanes.bd.every(s => s.on === false)).toBe(true)
+    })
+  })
+
+  describe('SetBarParam', () => {
+    it('sets a known key', () => {
+      ProjectStore.dispatch(SetBarParam(PATTERN_ID, 0, 'shuffle', 0.4))
+      expect(pattern().bars[0].shuffle).toBe(0.4)
+    })
+
+    it('ignores an unknown key', () => {
+      ProjectStore.dispatch(SetBarParam(PATTERN_ID, 0, 'bogus', 42))
+      expect(pattern().bars[0].bogus).toBeUndefined()
+    })
+  })
+
+  describe('AddBar', () => {
+    it('copyFrom deep-copies the source bar with a fresh id, independent of the source', () => {
+      ProjectStore.dispatch(SetPatternStep(PATTERN_ID, 0, 'bd', 0, { on: true }))
+      ProjectStore.dispatch(AddBar(PATTERN_ID, { copyFrom: 0 }))
+      const p = pattern()
+      expect(p.bars).toHaveLength(2)
+      expect(p.bars[1].id).not.toBe(p.bars[0].id)
+      expect(p.bars[1].lanes.bd[0].on).toBe(true)
+      expect(p.chain).toEqual([0, 1])
+
+      // mutate the copy, source must be untouched
+      ProjectStore.dispatch(SetPatternStep(PATTERN_ID, 1, 'bd', 0, { on: false }))
+      expect(pattern().bars[0].lanes.bd[0].on).toBe(true)
+      expect(pattern().bars[1].lanes.bd[0].on).toBe(false)
+    })
+
+    it('empty bar has all steps off and is appended to chain', () => {
+      ProjectStore.dispatch(AddBar(PATTERN_ID))
+      const p = pattern()
+      expect(p.bars).toHaveLength(2)
+      expect(p.bars[1].lanes.bd.every(s => s.on === false)).toBe(true)
+      expect(p.chain).toEqual([0, 1])
+    })
+  })
+
+  describe('RemoveBar', () => {
+    function threeBars() {
+      ProjectStore.dispatch(AddBar(PATTERN_ID)) // index 1
+      ProjectStore.dispatch(AddBar(PATTERN_ID)) // index 2
+      ProjectStore.dispatch(SetChain(PATTERN_ID, [0, 1, 1, 2, 0]))
+    }
+
+    it('drops the middle bar, drops chain entries pointing at it, decrements entries above it', () => {
+      threeBars()
+      ProjectStore.dispatch(RemoveBar(PATTERN_ID, 1))
+      const p = pattern()
+      expect(p.bars).toHaveLength(2)
+      expect(p.chain).toEqual([0, 1, 0])
+    })
+
+    it('is a no-op when only one bar remains', () => {
+      const before = pattern()
+      expect(before).toBeUndefined() // pattern not created until first dispatch
+      ProjectStore.dispatch(SetCurrentBar(PATTERN_ID, 0)) // creates '909-main' lazily
+      const stateBefore = ProjectStore.getState()
+      ProjectStore.dispatch(RemoveBar(PATTERN_ID, 0))
+      expect(ProjectStore.getState()).toEqual(stateBefore)
+    })
+
+    it('clamps currentBar when it pointed at or past the removed bar', () => {
+      threeBars()
+      ProjectStore.dispatch(SetCurrentBar(PATTERN_ID, 2))
+      ProjectStore.dispatch(RemoveBar(PATTERN_ID, 2))
+      expect(pattern().currentBar).toBe(1)
+    })
+  })
+
+  describe('SetCurrentBar / SetChain / ClearBar', () => {
+    it('SetCurrentBar changes editor selection, ignores out-of-range', () => {
+      ProjectStore.dispatch(AddBar(PATTERN_ID))
+      ProjectStore.dispatch(SetCurrentBar(PATTERN_ID, 1))
+      expect(pattern().currentBar).toBe(1)
+      ProjectStore.dispatch(SetCurrentBar(PATTERN_ID, 99))
+      expect(pattern().currentBar).toBe(1)
+    })
+
+    it('SetChain replaces the play order wholesale', () => {
+      ProjectStore.dispatch(AddBar(PATTERN_ID))
+      ProjectStore.dispatch(SetChain(PATTERN_ID, [1, 0, 1]))
+      expect(pattern().chain).toEqual([1, 0, 1])
+    })
+
+    it('ClearBar resets all lanes of one bar, leaves others alone', () => {
+      ProjectStore.dispatch(SetPatternStep(PATTERN_ID, 0, 'bd', 0, { on: true }))
+      ProjectStore.dispatch(AddBar(PATTERN_ID, { copyFrom: 0 }))
+      ProjectStore.dispatch(ClearBar(PATTERN_ID, 0))
+      const p = pattern()
+      expect(p.bars[0].lanes.bd.every(s => s.on === false)).toBe(true)
+      expect(p.bars[1].lanes.bd[0].on).toBe(true)
+    })
+  })
+
+  describe('migrate', () => {
+    it('v2 project gains patterns and version 3, existing tracks/racks untouched', () => {
+      const v2 = {
+        version: 2,
+        bpm: 120,
+        tracks: [{ id: 't1', type: 'midi', instrument: { type: 'palette', paletteKey: 'fm' } }],
+        racks: { r1: { id: 'r1', name: 'Rack', modules: [], cables: [] } }
+      }
+      const next = migrate(v2)
+      expect(next.version).toBe(3)
+      expect(next.patterns).toEqual({})
+      expect(next.tracks).toEqual(v2.tracks)
+      expect(next.racks).toEqual(v2.racks)
+    })
+  })
+
+  describe('nextChainPos', () => {
+    it('advances within range', () => {
+      expect(nextChainPos(0, 3)).toBe(1)
+      expect(nextChainPos(1, 3)).toBe(2)
+    })
+
+    it('wraps at the end', () => {
+      expect(nextChainPos(2, 3)).toBe(0)
+    })
+
+    it('handles a single-entry chain', () => {
+      expect(nextChainPos(0, 1)).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
## What

Two related changes, plus a deploy script carried forward from earlier work.

### 909 pattern bars

The `Pattern` dropdown rendered four slots `A1–A4` and had no event listener at all — it was cosmetic markup. The view held exactly one pattern in component state, never persisted, so everything programmed died on unmount.

Replaced with a bar strip: numbered buttons showing how many bars exist, `+` for an empty bar, `⧉ Copy Bar` to fork the current one. Transport splits into **Play Bar** and **Play Chain** sharing one Stop — auditioning the bar you are editing and hearing the whole thing are different intents and both are wanted constantly.

Bars now live in `ProjectStore.state.patterns` (schema 2 → 3), so they save with the project and undo works. `chain` holds indices, so a bar repeats without duplicating its lanes. Shuffle, flam, `lastStep` and accent are per-bar — a fill with different swing is the point of having bars.

Chain advance rides the existing `LookaheadScheduler` rather than a second scheduler. It reassigns `schedulerLoop.steps` at `stepIndex === 0`, never at the outgoing bar's last step: the wrap `(lastStep-1+1) % steps` has to use the outgoing bar's length to land on zero, so swapping earlier truncates any bar longer than its predecessor.

Glow comes from a `barAtStepTime` array written beside `stepTimes` at schedule time. The RAF loop reads it with the `bestStep` it already computes and only paints — audio runs ahead of paint, so advancing the bar from RAF would light the wrong button. `selected` and `bar-playing` are separate classes so a bar can show both.

### Shared transport header

BPM existed twice — a range slider in the synth view and a number input in the arrange toolbar, both bound to the same `state.bpm`. Master volume existed only in the synth view and vanished elsewhere. The play button physically moved depending on the open tool.

One `#global-header` above `#project-bar` now owns BPM, master volume and mode-aware Play/Stop, plus a `#header-view-slot`. `initMasterVolume` + `initBPM` + the transport half of `initArrangeTransport` collapse into `initGlobalHeader`.

## Verification

Driven in the built app, not only in tests. Programmed a 4-bar amen break entirely through real click handlers.

- Chain wraps 1→2→3→4→1; measured bar holds 1763/1757/1749 ms against 1765 ms theoretical for 16 steps at 136 BPM.
- **Mixed-length chain**, the highest-risk path: bar 2 set to `LAST 8` held 827 ms (882 ms theoretical) and bar 3 still played its full 1757 ms. No truncation, no overrun.
- Both glow states compose on one button.
- BPM set once in the header reaches the 909 step clock and survives a view switch; all four old duplicate controls gone from the DOM.
- No console errors.

One bug found this way and fixed in `a5b0e39`: global Play stayed disabled after leaving the 909, because the hook keyed off palette alone and `switchMode` never re-runs `switchPalette` — arrange playback was unreachable once you had opened the 909.

`npm test`: 40 files / 605 tests. `npm run build` clean.

## Notes

- Specs are in `specs/tr-909-pattern-bars.md` and `specs/shared-transport-header.md`.
- Shuffle/flam/accent are per-bar by design, so swing is dialed per bar rather than once for the pattern.
- Arrangement clips referencing a `patternId` remain out of scope (909 spec Phase D). `SetChain` is exported but unused — no UI yet for reordering the raw chain.
- Includes `scripts/redeploy.sh` from earlier work: Flux tracks `main` correctly, but the manifest pins the moving `:main` tag, so a merge touching no YAML leaves the Deployment byte-identical and no pod is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMqb76wkSpNtRu7Uizw6oA