### PR TITLE
feat(909): real TR-909 voice architecture + bottom-up drum grid

### DIFF
--- a/src/renderer/js/components/tr909-view.js
+++ b/src/renderer/js/components/tr909-view.js
@@ -15,6 +15,10 @@ import ProjectStore, {
 const STEPS = 16
 const PATTERN_ID = '909-main'
 
+// Grid rows read bottom-up: BD on the bottom row, RD on the top, the way a
+// drummer sits behind the kit. INSTRUMENTS stays low-to-high everywhere else.
+const LANE_ORDER = [...INSTRUMENTS].reverse()
+
 function formatPct(v) {
   return Math.round(v * 100)
 }
@@ -170,17 +174,18 @@ export class Tr909View {
               <span>${this.selectedInstrument().name}</span>
               <button class="tr909-audition" data-action="audition">Trig</button>
             </div>
-            <div class="tr909-steps" role="grid" aria-label="Selected instrument steps">
-              ${Array.from({ length: STEPS }, (_, i) => this.renderStepButton(bar, this.selectedInstrumentId, i)).join('')}
-            </div>
-            <div class="tr909-sub-lanes">
-              <div class="tr909-sub-label">Accent</div>
-              <div class="tr909-mini-steps">${Array.from({ length: STEPS }, (_, i) => this.renderMiniButton(bar, 'accent', i)).join('')}</div>
-              <div class="tr909-sub-label">Flam</div>
-              <div class="tr909-mini-steps">${Array.from({ length: STEPS }, (_, i) => this.renderMiniButton(bar, 'flam', i)).join('')}</div>
+            <div class="tr909-lane-row tr909-selected-lane" role="grid" aria-label="Selected instrument steps">
+              <span class="tr909-lane-label">${this.selectedInstrument().label}</span>
+              <div class="tr909-steps">
+                ${Array.from({ length: STEPS }, (_, i) => this.renderStepButton(bar, this.selectedInstrumentId, i)).join('')}
+              </div>
             </div>
             <div class="tr909-all-lanes"${this.showAllLanes ? '' : ' hidden'}>
-              ${INSTRUMENTS.map(inst => this.renderAllLane(bar, inst)).join('')}
+              ${LANE_ORDER.map(inst => this.renderAllLane(bar, inst)).join('')}
+            </div>
+            <div class="tr909-sub-lanes">
+              ${this.renderSubLane(bar, 'accent', 'Accent')}
+              ${this.renderSubLane(bar, 'flam', 'Flam')}
             </div>
           </div>
           <div class="tr909-params">
@@ -240,6 +245,17 @@ export class Tr909View {
     `
   }
 
+  renderSubLane(bar, key, label) {
+    return `
+      <div class="tr909-lane-row">
+        <span class="tr909-lane-label">${label}</span>
+        <div class="tr909-mini-steps">
+          ${Array.from({ length: STEPS }, (_, i) => this.renderMiniButton(bar, key, i)).join('')}
+        </div>
+      </div>
+    `
+  }
+
   renderMiniButton(bar, key, index) {
     const step = bar.lanes[this.selectedInstrumentId][index]
     return `<button class="tr909-mini${step[key] ? ' on' : ''}" data-sub="${key}" data-step="${index}" aria-pressed="${step[key]}"></button>`
@@ -247,8 +263,8 @@ export class Tr909View {
 
   renderAllLane(bar, inst) {
     return `
-      <div class="tr909-grid-row" style="--inst-color:${inst.color}">
-        <button class="tr909-grid-label" data-inst="${inst.id}">${inst.label}</button>
+      <div class="tr909-lane-row" style="--inst-color:${inst.color}">
+        <button class="tr909-lane-label tr909-grid-label" data-inst="${inst.id}">${inst.label}</button>
         <div class="tr909-grid-steps">
           ${Array.from({ length: STEPS }, (_, i) => this.renderGridCell(bar, inst.id, i)).join('')}
         </div>

--- a/src/renderer/js/drums/tr909-kit.js
+++ b/src/renderer/js/drums/tr909-kit.js
@@ -23,12 +23,111 @@ const PARAM_DEFS = {
 
 let activeOpenHat = null
 
-function createNoiseBuffer(ctx, duration) {
-  const length = Math.max(1, Math.ceil(ctx.sampleRate * duration))
-  const buffer = ctx.createBuffer(1, length, ctx.sampleRate)
-  const data = buffer.getChannelData(0)
-  for (let i = 0; i < length; i++) data[i] = Math.random() * 2 - 1
-  return buffer
+// ---------------------------------------------------------------------------
+// Per-context buffer/curve cache. Keyed by context so the offline bounce
+// context builds its own set at its own sample rate.
+// ---------------------------------------------------------------------------
+const CACHE = new WeakMap()
+
+function cached(ctx, key, make) {
+  let map = CACHE.get(ctx)
+  if (!map) { map = new Map(); CACHE.set(ctx, map) }
+  if (!map.has(key)) map.set(key, make())
+  return map.get(key)
+}
+
+const NOISE_DUR = 2
+
+function noiseBuffer(ctx) {
+  return cached(ctx, 'noise', () => {
+    const len = Math.max(1, Math.ceil(ctx.sampleRate * NOISE_DUR))
+    const buffer = ctx.createBuffer(1, len, ctx.sampleRate)
+    const data = buffer.getChannelData(0)
+    for (let i = 0; i < len; i++) data[i] = Math.random() * 2 - 1
+    return buffer
+  })
+}
+
+// One looping white-noise source read from a random offset, so successive hits
+// do not phase-lock onto the same noise the way a per-hit buffer would.
+function noiseSource(ctx) {
+  const node = ctx.createBufferSource()
+  node.buffer = noiseBuffer(ctx)
+  node.loop = true
+  return node
+}
+
+function driveCurve(ctx, amount) {
+  return cached(ctx, `drive:${amount}`, () => {
+    const n = 1024
+    const curve = new Float32Array(n)
+    const norm = Math.tanh(amount)
+    for (let i = 0; i < n; i++) {
+      const x = (i / (n - 1)) * 2 - 1
+      curve[i] = Math.tanh(x * amount) / norm
+    }
+    return curve
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Metallic ROM voices (CH / OH / CR / RD).
+//
+// The 909's cymbals are not analog: a counter clocks 6-bit PCM out of ROM into
+// a DAC, then a VCA shapes it and a lowpass strips the sample clock. TUNE
+// changes the clock rate. We reproduce that: render a gritty inharmonic source
+// once per context, quantize it to 6 bits, sample-and-hold it down to the ROM
+// clock rate, and play it back through a VCA with playbackRate as TUNE.
+// ---------------------------------------------------------------------------
+const ROM_RATE = 32000
+const ROM_LEVELS = (1 << 6) - 1
+
+const METAL = {
+  hat:   { dur: 1.4, base: 318, ratios: [1, 1.5, 2.08, 2.715, 3.395, 4.105], metal: 0.62, ring: 0.34, noise: 0.5,  romDecay: 0.9 },
+  crash: { dur: 3.4, base: 246, ratios: [1, 1.41, 1.87, 2.63, 3.31, 4.42],   metal: 0.5,  ring: 0.3,  noise: 0.78, romDecay: 2.6 },
+  ride:  { dur: 2.8, base: 292, ratios: [1, 1.35, 1.72, 2.24, 2.91, 3.62],   metal: 0.72, ring: 0.42, noise: 0.28, romDecay: 2.0 },
+}
+
+function metalBuffer(ctx, kind) {
+  return cached(ctx, `metal:${kind}`, () => {
+    const spec = METAL[kind]
+    const len = Math.max(1, Math.ceil(ctx.sampleRate * spec.dur))
+    const buffer = ctx.createBuffer(1, len, ctx.sampleRate)
+    const data = buffer.getChannelData(0)
+    const dt = 1 / ROM_RATE
+    const quant = 2 / ROM_LEVELS
+    const inc = spec.ratios.map(r => spec.base * r * dt)
+    const phase = spec.ratios.map(() => Math.random())
+    const decayK = Math.exp(-dt / spec.romDecay)
+    const clockInc = ROM_RATE / ctx.sampleRate
+    let clock = 1
+    let env = 1
+    let held = 0
+    let seed = 987654321
+    for (let i = 0; i < len; i++) {
+      clock += clockInc
+      if (clock >= 1) {
+        clock -= 1
+        let square = 0
+        for (let k = 0; k < phase.length; k++) {
+          phase[k] += inc[k]
+          if (phase[k] >= 1) phase[k] -= 1
+          square += phase[k] < 0.5 ? 1 : -1
+        }
+        square /= phase.length
+        // Ring-modulating two of the partials fills the gaps between the square
+        // stack's harmonics — that is what stops it sounding like an 808 hat.
+        const ring = (phase[0] < 0.5 ? 1 : -1) * (phase[3] < 0.5 ? 1 : -1)
+        seed = (seed * 1103515245 + 12345) & 0x7fffffff
+        const white = seed / 0x40000000 - 1
+        const raw = square * spec.metal + ring * spec.ring + white * spec.noise
+        held = Math.round(Math.tanh(raw * 2.1) * env / quant) * quant
+        env *= decayK
+      }
+      data[i] = held
+    }
+    return buffer
+  })
 }
 
 function safeExp(param, value, time) {
@@ -62,174 +161,230 @@ function baseVelocity(params, event = {}) {
   return Math.min(1.65, (event.velocity ?? 0.85) * (params.level ?? 0.75) * accentBoost * 1.2)
 }
 
+// ---------------------------------------------------------------------------
+// Analog voices
+// ---------------------------------------------------------------------------
+
 function kick(ctx, output, params, event, t) {
   const v = baseVelocity(params, event)
-  const decay = 0.18 + params.decay * 0.75
-  const tune = 42 + params.tune * 42
+  const decay = 0.11 + params.decay * 0.85
+  const f0 = 38 + params.tune * 34
   const osc = ctx.createOscillator()
-  const click = ctx.createOscillator()
   const gain = ctx.createGain()
-  const clickGain = ctx.createGain()
   const drive = ctx.createWaveShaper()
-  drive.curve = new Float32Array([-1, -0.62, 0, 0.62, 1])
+  drive.curve = driveCurve(ctx, 1.9)
   osc.type = 'sine'
-  osc.frequency.setValueAtTime(tune * 2.2, t)
-  safeExp(osc.frequency, tune, t + Math.max(0.035, decay * 0.45))
+  // The 909's pitch envelope is over in ~50 ms — that snap is the whole sound.
+  osc.frequency.setValueAtTime(f0 * 4.6, t)
+  safeExp(osc.frequency, f0 * 1.35, t + 0.011)
+  safeExp(osc.frequency, f0, t + 0.055)
   gain.gain.setValueAtTime(0.0001, t)
-  gain.gain.linearRampToValueAtTime(v, t + 0.004)
+  gain.gain.linearRampToValueAtTime(v, t + 0.002)
   safeExp(gain.gain, 0.0001, t + decay)
-  click.type = 'triangle'
-  click.frequency.value = 900 + params.attack * 2400
-  clickGain.gain.setValueAtTime(v * params.attack * 0.35, t)
-  safeExp(clickGain.gain, 0.0001, t + 0.025)
   osc.connect(gain); gain.connect(drive); drive.connect(output)
-  click.connect(clickGain); clickGain.connect(output)
-  osc.start(t); click.start(t)
-  osc.stop(t + decay + 0.05); click.stop(t + 0.04)
-  osc.onended = () => cleanup([osc, gain, drive, click, clickGain])
+
+  // ATTACK sets the level of a filtered noise burst, not a pitched click.
+  const click = noiseSource(ctx)
+  const hp = ctx.createBiquadFilter()
+  const clickGain = ctx.createGain()
+  hp.type = 'highpass'
+  hp.frequency.value = 1400
+  clickGain.gain.setValueAtTime(v * (0.08 + params.attack * 0.5), t)
+  safeExp(clickGain.gain, 0.0001, t + 0.0045)
+  click.connect(hp); hp.connect(clickGain); clickGain.connect(output)
+
+  osc.start(t)
+  click.start(t, Math.random() * NOISE_DUR)
+  osc.stop(t + decay + 0.05)
+  click.stop(t + 0.03)
+  osc.onended = () => cleanup([osc, gain, drive, click, hp, clickGain])
   return { stop(time = ctx.currentTime) { voiceStop([osc, click], gain, time) } }
 }
 
+// Stock 909 snare oscillators sit at 238 Hz and 476 Hz (Roland service notes).
+const SNARE_OSCS = [[238, 0.5, 0.105], [476, 0.3, 0.062]]
+
 function snare(ctx, output, params, event, t) {
   const v = baseVelocity(params, event)
-  const toneFreq = 150 + params.tune * 150
-  const noiseDur = 0.08 + params.snappy * 0.32
-  const body = ctx.createOscillator()
-  const bodyGain = ctx.createGain()
-  const noise = ctx.createBufferSource()
-  const filter = ctx.createBiquadFilter()
+  const scale = 0.72 + params.tune * 0.62
+  const noiseDur = 0.055 + params.snappy * 0.2
+  const out = ctx.createGain()
+  out.gain.value = 1
+  out.connect(output)
+  const oscNodes = SNARE_OSCS.map(([freq, amp, dec]) => {
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+    osc.type = 'triangle'
+    osc.frequency.setValueAtTime(freq * scale * 1.18, t)
+    safeExp(osc.frequency, freq * scale, t + 0.022)
+    gain.gain.setValueAtTime(v * amp, t)
+    safeExp(gain.gain, 0.0001, t + dec)
+    osc.connect(gain); gain.connect(out)
+    osc.start(t); osc.stop(t + dec + 0.03)
+    return [osc, gain]
+  }).flat()
+  // Snare cable noise: highpass (TONE) into a fixed lowpass, per the circuit.
+  const noise = noiseSource(ctx)
+  const hp = ctx.createBiquadFilter()
+  const lp = ctx.createBiquadFilter()
   const noiseGain = ctx.createGain()
-  body.type = 'triangle'
-  body.frequency.setValueAtTime(toneFreq, t)
-  safeExp(body.frequency, toneFreq * 0.72, t + 0.12)
-  bodyGain.gain.setValueAtTime(v * 0.55, t)
-  safeExp(bodyGain.gain, 0.0001, t + 0.16)
-  noise.buffer = createNoiseBuffer(ctx, noiseDur + 0.03)
-  filter.type = 'bandpass'
-  filter.frequency.value = 1200 + params.tone * 4200
-  filter.Q.value = 0.9
-  noiseGain.gain.setValueAtTime(v * (0.25 + params.snappy * 0.75), t)
+  hp.type = 'highpass'; hp.frequency.value = 900 + params.tone * 5400; hp.Q.value = 0.8
+  lp.type = 'lowpass'; lp.frequency.value = 7800
+  noiseGain.gain.setValueAtTime(v * (0.26 + params.snappy * 0.6), t)
   safeExp(noiseGain.gain, 0.0001, t + noiseDur)
-  body.connect(bodyGain); bodyGain.connect(output)
-  noise.connect(filter); filter.connect(noiseGain); noiseGain.connect(output)
-  body.start(t); noise.start(t)
-  body.stop(t + 0.22); noise.stop(t + noiseDur + 0.05)
-  noise.onended = () => cleanup([body, bodyGain, noise, filter, noiseGain])
-  return { stop(time = ctx.currentTime) { voiceStop([body, noise], noiseGain, time) } }
+  noise.connect(hp); hp.connect(lp); lp.connect(noiseGain); noiseGain.connect(out)
+  noise.start(t, Math.random() * NOISE_DUR)
+  noise.stop(t + noiseDur + 0.05)
+  noise.onended = () => cleanup([...oscNodes, noise, hp, lp, noiseGain, out])
+  return { stop(time = ctx.currentTime) { voiceStop([...oscNodes, noise], out, time) } }
 }
+
+// The 909 tom stacks three oscillators at 1 : 1.5 : 2.77 plus a noise attack.
+const TOM_RATIOS = [[1, 1, 1], [1.5, 0.26, 0.5], [2.77, 0.13, 0.32]]
 
 function tom(ctx, output, params, event, t, baseFreq) {
   const v = baseVelocity(params, event)
   const decay = 0.12 + params.decay * 0.72
-  const osc = ctx.createOscillator()
-  const gain = ctx.createGain()
-  osc.type = 'sine'
   const freq = baseFreq * (0.72 + params.tune * 0.68)
-  osc.frequency.setValueAtTime(freq * 1.35, t)
-  safeExp(osc.frequency, freq, t + 0.07)
-  gain.gain.setValueAtTime(v, t)
-  safeExp(gain.gain, 0.0001, t + decay)
-  osc.connect(gain); gain.connect(output)
-  osc.start(t); osc.stop(t + decay + 0.05)
-  osc.onended = () => cleanup([osc, gain])
-  return { stop(time = ctx.currentTime) { voiceStop([osc], gain, time) } }
+  const out = ctx.createGain()
+  out.gain.value = 1
+  out.connect(output)
+  const oscNodes = TOM_RATIOS.map(([ratio, amp, decMul]) => {
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+    osc.type = 'triangle'
+    osc.frequency.setValueAtTime(freq * ratio * 1.42, t)
+    safeExp(osc.frequency, freq * ratio, t + 0.05)
+    gain.gain.setValueAtTime(v * amp * 0.85, t)
+    safeExp(gain.gain, 0.0001, t + decay * decMul)
+    osc.connect(gain); gain.connect(out)
+    osc.start(t); osc.stop(t + decay + 0.05)
+    return [osc, gain]
+  }).flat()
+  const noise = noiseSource(ctx)
+  const bp = ctx.createBiquadFilter()
+  const noiseGain = ctx.createGain()
+  bp.type = 'bandpass'; bp.frequency.value = freq * 5.5; bp.Q.value = 1.1
+  noiseGain.gain.setValueAtTime(v * 0.3, t)
+  safeExp(noiseGain.gain, 0.0001, t + 0.035)
+  noise.connect(bp); bp.connect(noiseGain); noiseGain.connect(out)
+  noise.start(t, Math.random() * NOISE_DUR)
+  noise.stop(t + 0.07)
+  oscNodes[0].onended = () => cleanup([...oscNodes, noise, bp, noiseGain, out])
+  return { stop(time = ctx.currentTime) { voiceStop([...oscNodes, noise], out, time) } }
 }
 
 function rim(ctx, output, params, event, t) {
   const v = baseVelocity(params, event)
-  const osc = ctx.createOscillator()
-  const gain = ctx.createGain()
-  const filter = ctx.createBiquadFilter()
-  osc.type = 'square'
-  osc.frequency.value = 650 + params.tone * 900
-  filter.type = 'bandpass'
-  filter.frequency.value = 1300 + params.tone * 1600
-  filter.Q.value = 8
-  gain.gain.setValueAtTime(v * 1.05, t)
-  safeExp(gain.gain, 0.0001, t + 0.055)
-  osc.connect(filter); filter.connect(gain); gain.connect(output)
-  osc.start(t); osc.stop(t + 0.08)
-  osc.onended = () => cleanup([osc, filter, gain])
-  return { stop(time = ctx.currentTime) { voiceStop([osc], gain, time) } }
-}
-
-function clap(ctx, output, params, event, t) {
-  const nodes = []
-  const v = baseVelocity(params, event)
   const out = ctx.createGain()
   out.gain.value = 1
   out.connect(output)
-  ;[0, 0.012, 0.024, 0.043].forEach((offset, i) => {
-    const noise = ctx.createBufferSource()
-    const filter = ctx.createBiquadFilter()
+  const bp = ctx.createBiquadFilter()
+  bp.type = 'bandpass'
+  bp.frequency.value = 1500 + params.tone * 1400
+  bp.Q.value = 6
+  bp.connect(out)
+  // Two short pulses an octave apart, plus a noise tick. ~35 ms total.
+  const oscNodes = [[220, 1], [440, 0.7]].map(([freq, amp]) => {
+    const osc = ctx.createOscillator()
     const gain = ctx.createGain()
-    const dur = i === 3 ? 0.08 + params.decay * 0.42 : 0.024
-    noise.buffer = createNoiseBuffer(ctx, dur + 0.02)
-    filter.type = 'bandpass'
-    filter.frequency.value = 950 + params.tone * 1700
-    filter.Q.value = 0.9
-      gain.gain.setValueAtTime(v * (i === 3 ? 1.0 : 0.58), t + offset)
+    osc.type = 'square'
+    osc.frequency.value = freq * (0.85 + params.tone * 0.5)
+    gain.gain.setValueAtTime(v * amp * 0.85, t)
+    safeExp(gain.gain, 0.0001, t + 0.028)
+    osc.connect(gain); gain.connect(bp)
+    osc.start(t); osc.stop(t + 0.04)
+    return [osc, gain]
+  }).flat()
+  const noise = noiseSource(ctx)
+  const noiseGain = ctx.createGain()
+  noiseGain.gain.setValueAtTime(v * 0.5, t)
+  safeExp(noiseGain.gain, 0.0001, t + 0.008)
+  noise.connect(noiseGain); noiseGain.connect(bp)
+  noise.start(t, Math.random() * NOISE_DUR)
+  noise.stop(t + 0.03)
+  oscNodes[0].onended = () => cleanup([...oscNodes, noise, noiseGain, bp, out])
+  return { stop(time = ctx.currentTime) { voiceStop([...oscNodes, noise], out, time) } }
+}
+
+// Four VCA hits ~10 ms apart, the last one carrying the room tail.
+const CLAP_OFFSETS = [0, 0.010, 0.020, 0.031]
+
+function clap(ctx, output, params, event, t) {
+  const v = baseVelocity(params, event)
+  const out = ctx.createGain()
+  out.gain.value = 1
+  const bp = ctx.createBiquadFilter()
+  const hp = ctx.createBiquadFilter()
+  bp.type = 'bandpass'
+  bp.frequency.value = 900 + params.tone * 900
+  bp.Q.value = 2.6
+  hp.type = 'highpass'
+  hp.frequency.value = 700
+  hp.connect(bp); bp.connect(out); out.connect(output)
+  const nodes = []
+  CLAP_OFFSETS.forEach((offset, i) => {
+    const last = i === CLAP_OFFSETS.length - 1
+    const noise = noiseSource(ctx)
+    const gain = ctx.createGain()
+    const dur = last ? 0.09 + params.decay * 0.4 : 0.0075
+    gain.gain.setValueAtTime(v * (last ? 0.95 : 0.72), t + offset)
     safeExp(gain.gain, 0.0001, t + offset + dur)
-    noise.connect(filter); filter.connect(gain); gain.connect(out)
-    noise.start(t + offset); noise.stop(t + offset + dur + 0.04)
-    nodes.push(noise, filter, gain)
+    noise.connect(gain); gain.connect(hp)
+    noise.start(t + offset, Math.random() * NOISE_DUR)
+    noise.stop(t + offset + dur + 0.04)
+    nodes.push(noise, gain)
   })
-  nodes[0].onended = () => cleanup([...nodes, out])
-  return { stop(time = ctx.currentTime) { voiceStop(nodes.filter(n => typeof n.stop === 'function'), out, time) } }
+  nodes[0].onended = () => cleanup([...nodes, hp, bp, out])
+  return { stop(time = ctx.currentTime) { voiceStop(nodes, out, time) } }
+}
+
+// ---------------------------------------------------------------------------
+// ROM playback voices
+// ---------------------------------------------------------------------------
+
+const METAL_VOICES = {
+  ch: { rom: 'hat',   amp: 0.95, hp: 6400, peak: null,             decay: p => 0.018 + p.decay * 0.2 },
+  oh: { rom: 'hat',   amp: 0.9,  hp: 5000, peak: null,             decay: p => 0.08 + p.decay * 0.9 },
+  cr: { rom: 'crash', amp: 1.0,  hp: 2600, peak: null,             decay: p => 0.6 + p.decay * 1.5 },
+  rd: { rom: 'ride',  amp: 0.95, hp: 3000, peak: [5600, 3.5, 7],   decay: p => 0.45 + p.decay * 1.3 },
 }
 
 function metallic(ctx, output, params, event, t, kind) {
-  const isClosed = kind === 'ch'
-  const isOpen = kind === 'oh'
-  const decay = isClosed ? params.decay : 0.25 + params.decay
+  const spec = METAL_VOICES[kind]
   const v = baseVelocity(params, event)
-  const out = ctx.createGain()
+  const decay = spec.decay(params)
+  const src = ctx.createBufferSource()
   const hp = ctx.createBiquadFilter()
-  hp.type = 'highpass'
-  hp.frequency.value = 5200 + params.tune * 5200
-  out.gain.setValueAtTime(v * (isClosed ? 0.9 : 1.05), t)
-  safeExp(out.gain, 0.0001, t + decay)
-  hp.connect(out); out.connect(output)
-  const oscs = [1, 1.34, 1.49, 1.8, 2.14, 2.46].map((ratio, i) => {
-    const osc = ctx.createOscillator()
-    osc.type = 'square'
-    osc.frequency.value = (210 + params.tune * 110) * ratio
-    const g = ctx.createGain()
-    g.gain.value = 0.1 + (i % 2) * 0.025
-    osc.connect(g); g.connect(hp)
-    osc.start(t); osc.stop(t + decay + 0.05)
-    return [osc, g]
-  }).flat()
-  const handle = { stop(time = ctx.currentTime) { voiceStop(oscs.filter(n => typeof n.stop === 'function'), out, time, 0.012) } }
-  oscs[0].onended = () => cleanup([...oscs, hp, out])
-  if (isClosed && activeOpenHat) activeOpenHat.stop(t)
-  if (isOpen) activeOpenHat = handle
+  const lp = ctx.createBiquadFilter()
+  const gain = ctx.createGain()
+  src.buffer = metalBuffer(ctx, spec.rom)
+  // TUNE is the ROM clock rate, exactly as on the hardware.
+  src.playbackRate.value = 0.75 + params.tune * 0.7
+  hp.type = 'highpass'; hp.frequency.value = spec.hp; hp.Q.value = 0.7
+  lp.type = 'lowpass'; lp.frequency.value = 13500
+  gain.gain.setValueAtTime(v * spec.amp, t)
+  safeExp(gain.gain, 0.0001, t + decay)
+  let tail = lp
+  const extra = []
+  if (spec.peak) {
+    const peak = ctx.createBiquadFilter()
+    peak.type = 'peaking'
+    peak.frequency.value = spec.peak[0]
+    peak.Q.value = spec.peak[1]
+    peak.gain.value = spec.peak[2]
+    lp.connect(peak)
+    tail = peak
+    extra.push(peak)
+  }
+  src.connect(hp); hp.connect(lp); tail.connect(gain); gain.connect(output)
+  src.start(t)
+  src.stop(t + decay + 0.05)
+  const handle = { stop(time = ctx.currentTime) { voiceStop([src], gain, time, 0.008) } }
+  src.onended = () => cleanup([src, hp, lp, ...extra, gain])
+  if (kind === 'ch' && activeOpenHat) activeOpenHat.stop(t)
+  if (kind === 'oh') activeOpenHat = handle
   return handle
-}
-
-function cymbal(ctx, output, params, event, t, isRide) {
-  const v = baseVelocity(params, event)
-  const decay = 0.35 + params.decay
-  const out = ctx.createGain()
-  const hp = ctx.createBiquadFilter()
-  const bp = ctx.createBiquadFilter()
-  hp.type = 'highpass'; hp.frequency.value = 3200 + params.tune * 3800
-  bp.type = 'bandpass'; bp.frequency.value = isRide ? 6200 : 4800; bp.Q.value = isRide ? 4 : 1.6
-  out.gain.setValueAtTime(v * (isRide ? 0.95 : 1.08), t)
-  safeExp(out.gain, 0.0001, t + decay)
-  hp.connect(bp); bp.connect(out); out.connect(output)
-  const oscs = [1, 1.17, 1.31, 1.58, 1.92, 2.23].map(ratio => {
-    const osc = ctx.createOscillator()
-    const g = ctx.createGain()
-    osc.type = 'square'
-    osc.frequency.value = (310 + params.tune * 180) * ratio
-    g.gain.value = isRide ? 0.085 : 0.11
-    osc.connect(g); g.connect(hp)
-    osc.start(t); osc.stop(t + decay + 0.08)
-    return [osc, g]
-  }).flat()
-  oscs[0].onended = () => cleanup([...oscs, hp, bp, out])
-  return { stop(time = ctx.currentTime) { voiceStop(oscs.filter(n => typeof n.stop === 'function'), out, time, 0.02) } }
 }
 
 function createTr909Voice(ctx, output, instrumentId, kitParams, event = {}, time = ctx.currentTime) {
@@ -237,17 +392,17 @@ function createTr909Voice(ctx, output, instrumentId, kitParams, event = {}, time
   switch (instrumentId) {
     case 'bd': return kick(ctx, output, params, event, time)
     case 'sd': return snare(ctx, output, params, event, time)
-    case 'lt': return tom(ctx, output, params, event, time, 95)
-    case 'mt': return tom(ctx, output, params, event, time, 132)
-    case 'ht': return tom(ctx, output, params, event, time, 178)
+    case 'lt': return tom(ctx, output, params, event, time, 82)
+    case 'mt': return tom(ctx, output, params, event, time, 116)
+    case 'ht': return tom(ctx, output, params, event, time, 160)
     case 'rs': return rim(ctx, output, params, event, time)
     case 'cp': return clap(ctx, output, params, event, time)
-    case 'ch': return metallic(ctx, output, params, event, time, 'ch')
-    case 'oh': return metallic(ctx, output, params, event, time, 'oh')
-    case 'cr': return cymbal(ctx, output, params, event, time, false)
-    case 'rd': return cymbal(ctx, output, params, event, time, true)
+    case 'ch':
+    case 'oh':
+    case 'cr':
+    case 'rd': return metallic(ctx, output, params, event, time, instrumentId)
     default: return { stop() {} }
   }
 }
 
-export { INSTRUMENTS, PARAM_DEFS, makeKitParams, createTr909Voice }
+export { INSTRUMENTS, PARAM_DEFS, makeKitParams, createTr909Voice, metalBuffer, ROM_RATE }

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -874,6 +874,26 @@ input[type=range]::-moz-range-thumb {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  /* Every lane in the editor — selected instrument, drum grid, accent, flam —
+     shares this gutter and gap, so a given step lines up vertically across all
+     of them. Change them here, not per row. */
+  --lane-label: 54px;
+  --lane-gap: 4px;
+}
+
+.tr909-lane-row {
+  display: grid;
+  grid-template-columns: var(--lane-label) minmax(0, 1fr);
+  gap: var(--lane-gap);
+  align-items: center;
+}
+.tr909-lane-label {
+  color: var(--text-dim);
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  text-align: left;
+  overflow: hidden;
 }
 .tr909-lane-head {
   display: flex;
@@ -888,13 +908,13 @@ input[type=range]::-moz-range-thumb {
 .tr909-mini-steps,
 .tr909-grid-steps {
   display: grid;
-  grid-template-columns: repeat(16, minmax(28px, 1fr));
-  gap: 4px;
+  grid-template-columns: repeat(16, minmax(0, 1fr));
+  gap: var(--lane-gap);
 }
 
 .tr909-step {
   height: 52px;
-  min-width: 28px;
+  min-width: 0;
   border: 1px solid var(--border);
   background: var(--bg4);
   color: var(--text-dim);
@@ -916,20 +936,15 @@ input[type=range]::-moz-range-thumb {
 }
 
 .tr909-sub-lanes {
-  display: grid;
-  grid-template-columns: 56px 1fr;
-  gap: 5px 8px;
-  align-items: center;
-}
-.tr909-sub-label {
-  color: var(--text-dim);
-  font-size: 10px;
-  letter-spacing: 1px;
-  text-transform: uppercase;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  border-top: 1px solid var(--border);
+  padding-top: 8px;
 }
 .tr909-mini {
   height: 18px;
-  min-width: 20px;
+  min-width: 0;
   border: 1px solid var(--border);
   background: var(--bg3);
   cursor: pointer;
@@ -940,22 +955,16 @@ input[type=range]::-moz-range-thumb {
   border-color: var(--accent);
 }
 
+/* No max-height: the whole composer scrolls with #app rather than trapping the
+   grid in a nested scroller. */
 .tr909-all-lanes {
   display: flex;
   flex-direction: column;
   gap: 3px;
   margin-top: 2px;
-  max-height: 260px;
-  overflow-y: auto;
-}
-.tr909-grid-row {
-  display: grid;
-  grid-template-columns: 38px 1fr;
-  gap: 6px;
-  align-items: center;
 }
 .tr909-grid-label {
-  height: 22px;
+  height: 26px;
   background: var(--bg3);
   border: 1px solid var(--border);
   color: var(--inst-color);
@@ -963,8 +972,8 @@ input[type=range]::-moz-range-thumb {
   cursor: pointer;
 }
 .tr909-grid-cell {
-  height: 22px;
-  min-width: 18px;
+  height: 26px;
+  min-width: 0;
   background: var(--bg4);
   border: 1px solid var(--border);
   cursor: pointer;
@@ -1017,9 +1026,9 @@ input[type=range]::-moz-range-thumb {
   }
   .tr909-steps,
   .tr909-mini-steps,
-  .tr909-grid-steps { grid-template-columns: repeat(8, minmax(30px, 1fr)); }
+  .tr909-grid-steps { grid-template-columns: repeat(8, minmax(0, 1fr)); }
   .tr909-step { height: 44px; }
-  .tr909-editor { min-width: 0; }
+  .tr909-editor { min-width: 0; --lane-label: 36px; }
 }
 
 /* ─── Sequencer ────────────────────────────────────────────────────────────── */

--- a/tests/tr909-kit.test.js
+++ b/tests/tr909-kit.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest'
+import { INSTRUMENTS, makeKitParams, createTr909Voice, metalBuffer, ROM_RATE } from '../src/renderer/js/drums/tr909-kit.js'
+
+// Fake BaseAudioContext whose buffers actually retain what gets written.
+function makeCtx(sampleRate = 44100) {
+  const created = []
+  const param = () => ({
+    value: 0,
+    setValueAtTime: vi.fn(),
+    setTargetAtTime: vi.fn(),
+    linearRampToValueAtTime: vi.fn(),
+    exponentialRampToValueAtTime: vi.fn(),
+    cancelScheduledValues: vi.fn()
+  })
+  const node = (kind, extra = {}) => {
+    const n = { kind, connect: vi.fn(d => d), disconnect: vi.fn(), ...extra }
+    created.push(n)
+    return n
+  }
+  const source = (kind, extra) => node(kind, {
+    starts: 0, stops: 0,
+    start: vi.fn(function () { this.starts++ }),
+    stop: vi.fn(function () { this.stops++ }),
+    ...extra
+  })
+  return {
+    currentTime: 0,
+    sampleRate,
+    created,
+    createGain: () => node('gain', { gain: param() }),
+    createBiquadFilter: () => node('biquad', { type: 'lowpass', frequency: param(), Q: param(), gain: param(), detune: param() }),
+    createWaveShaper: () => node('shaper', { curve: null }),
+    createOscillator: () => source('osc', { type: 'sine', frequency: param(), detune: param() }),
+    createBufferSource: () => source('bufsrc', { buffer: null, loop: false, playbackRate: param() }),
+    createBuffer: (ch, len) => {
+      const data = new Float32Array(len)
+      return { numberOfChannels: ch, length: len, getChannelData: () => data }
+    }
+  }
+}
+
+describe('909 cymbal ROM', () => {
+  const ctx = makeCtx()
+  const data = metalBuffer(ctx, 'hat').getChannelData(0)
+
+  it('is quantized to 6 bits', () => {
+    const levels = new Set(data)
+    expect(levels.size).toBeLessThanOrEqual(64)
+    expect(levels.size).toBeGreaterThan(8) // not silence / not a couple of values
+  })
+
+  it('is sample-and-held at the ROM clock, not the context rate', () => {
+    let changes = 0
+    for (let i = 1; i < data.length; i++) if (data[i] !== data[i - 1]) changes++
+    const seconds = data.length / ctx.sampleRate
+    // Every held step is a ROM tick, but consecutive ticks can land on the same
+    // quantized level, so the change count is an under-count of the clock rate.
+    expect(changes / seconds).toBeLessThanOrEqual(ROM_RATE * 1.05)
+    expect(changes / seconds).toBeGreaterThan(ROM_RATE * 0.5)
+  })
+
+  it('caches per context', () => {
+    expect(metalBuffer(ctx, 'hat')).toBe(metalBuffer(ctx, 'hat'))
+    expect(metalBuffer(makeCtx(), 'hat')).not.toBe(metalBuffer(ctx, 'hat'))
+  })
+})
+
+describe('909 voices', () => {
+  it('start and schedule a stop for every source they create', () => {
+    const params = makeKitParams()
+    for (const inst of INSTRUMENTS) {
+      const ctx = makeCtx()
+      const out = ctx.createGain()
+      createTr909Voice(ctx, out, inst.id, params, { velocity: 1 }, 0)
+      const sources = ctx.created.filter(n => typeof n.start === 'function')
+      expect(sources.length, inst.id).toBeGreaterThan(0)
+      for (const src of sources) {
+        expect(src.starts, `${inst.id} ${src.kind} start`).toBe(1)
+        expect(src.stops, `${inst.id} ${src.kind} stop`).toBe(1)
+      }
+    }
+  })
+
+  it('chokes the open hat when a closed hat fires', () => {
+    const ctx = makeCtx()
+    const out = ctx.createGain()
+    const params = makeKitParams()
+    const oh = createTr909Voice(ctx, out, 'oh', params, {}, 0)
+    const spy = vi.spyOn(oh, 'stop')
+    createTr909Voice(ctx, out, 'ch', params, {}, 1)
+    expect(spy).toHaveBeenCalledWith(1)
+  })
+})

--- a/tests/tr909-view.test.js
+++ b/tests/tr909-view.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest'
+vi.mock('../src/renderer/js/audio-engine.js', () => ({
+  default: { init: vi.fn(), getContext: () => null, getMasterInput: () => null }
+}))
+import { Tr909View } from '../src/renderer/js/components/tr909-view.js'
+import { INSTRUMENTS } from '../src/renderer/js/drums/tr909-kit.js'
+
+function mount() {
+  const root = document.createElement('div')
+  const view = new Tr909View(root, { ensureAudio: async () => {} })
+  view.showAllLanes = true
+  view.render()
+  return { root, view }
+}
+
+describe('909 editor layout', () => {
+  it('stacks the drum grid bottom-up, BD on the bottom row', () => {
+    const { root, view } = mount()
+    const labels = [...root.querySelectorAll('.tr909-all-lanes .tr909-grid-label')].map(el => el.textContent)
+    expect(labels).toEqual([...INSTRUMENTS].reverse().map(i => i.label))
+    expect(labels.at(-1)).toBe('BD')
+    view.destroy()
+  })
+
+  it('puts accent and flam below the grid', () => {
+    const { root, view } = mount()
+    const editor = root.querySelector('.tr909-editor')
+    const order = [...editor.children].map(el => el.className)
+    expect(order.findIndex(c => c.includes('tr909-sub-lanes')))
+      .toBeGreaterThan(order.findIndex(c => c.includes('tr909-all-lanes')))
+    view.destroy()
+  })
+
+  // The three lane kinds used to carry different label gutters and gaps, so a
+  // given step sat at a different x in each. They must share one row template.
+  it('renders every lane with the same row template', () => {
+    const { root, view } = mount()
+    const lanes = [...root.querySelectorAll('.tr909-steps, .tr909-grid-steps, .tr909-mini-steps')]
+    expect(lanes.length).toBe(INSTRUMENTS.length + 3) // selected lane + grid + accent + flam
+    for (const lane of lanes) {
+      expect(lane.children.length).toBe(16)
+      expect(lane.parentElement.classList.contains('tr909-lane-row')).toBe(true)
+      expect(lane.parentElement.children.length).toBe(2) // label gutter + steps
+    }
+    view.destroy()
+  })
+})


### PR DESCRIPTION
## Sound

Hats, crash and ride were a 6-square-oscillator stack through a highpass — the **808/CR-78** metallic model. The 909 is a hybrid: only BD/SD/toms/rim/clap are analog; the cymbals are **6-bit PCM clocked out of ROM** through a DAC and VCA, with TUNE changing the ROM clock rate. Clean oscillators can't produce that grit.

| Voice | Change |
|---|---|
| CH/OH/CR/RD | Render an inharmonic source once per context, quantize to 6 bits, sample-and-hold to a 32 kHz ROM clock, play through a VCA. TUNE drives `playbackRate`, as the hardware clocks the ROM. Buffers cached per `AudioContext` so offline bounce builds its own at its own sample rate. Plain JS, no worklet — LAN plain-HTTP deploy unaffected. |
| BD | ATTACK is a highpassed noise burst instead of a pitched triangle; pitch sweep collapses in ~55 ms instead of up to 400 ms; drive waveshaper uses a real 1024-point tanh curve. |
| SD | Two oscillators at the stock 238/476 Hz per Roland service notes; noise through highpass (TONE) into a fixed 7.8 kHz lowpass. |
| Toms | Three oscillators at the measured 1:1.5:2.77 ratios plus the noise attack the 909 has and the old pure sine did not. |
| CP | Resonant bandpass behind a highpass, four hits 10 ms apart. |
| RS | 35 ms, two pulses an octave apart plus a noise tick. |

White noise now comes from one cached looping buffer read at a random offset rather than a fresh buffer allocated per hit.

Skipped shipping real 909 ROM samples: licensing is murky, it kills the TUNE/DECAY knobs, and it adds binary assets. Matching the hardware architecture gets there without any.

## Layout

The editor stacked three lane kinds with three different label gutters (0 / 56 / 38 px) and three different gaps (4 / 8 / 6 px), so a given step sat at a different x in each. All lanes now render as `.tr909-lane-row` against one `--lane-label` / `--lane-gap` pair on `.tr909-editor`.

- Drum grid reads bottom-up: BD on the bottom row through RD on the top.
- Accent and flam moved below the grid, behind a divider.
- Dropped the 260 px `max-height` on the grid — a nested scroller inside a page that already scrolls. Rows 22 px → 26 px.

Verified in the browser: all 14 lanes report identical left/right bounds, and the whole composer fits without an inner scroll.

## Tests

613 passing (+8). `tests/tr909-kit.test.js` asserts the ROM buffer really is 6-bit and really is held at 32 kHz, that every voice stops every source it starts, and that CH chokes OH. `tests/tr909-view.test.js` covers grid order, accent/flam placement, and the shared row template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMqb76wkSpNtRu7Uizw6oA