### PR TITLE
feat(rack): SCOPE draws, and a new 4-channel METER

### DIFF
--- a/specs/modular-rack-modules.md
+++ b/specs/modular-rack-modules.md
@@ -133,7 +133,8 @@ Priority: **P0** = required for the first shippable rack, **P1** = same release,
 | **OUT** | 4 | native | sums poly | `L` audio, `R` audio (normalled from L) | — | level 0–1, mute | P0 |
 | **AUDIO IN** | 4 | native | no | — | `L` audio, `R` audio | gain 0–2 | P1 |
 | **PARAM OUT** | 6 | native | no | `IN` cv | — | target (mixer/effect param picker), range min/max, smoothing 0–500 ms | P1 |
-| **SCOPE** | 12 | native | shows ch 1–4 | `A` any, `B` any, `TRIG` gate | — | time 1–500 ms/div, scale ±0.1…±2, mode (wave/xy/spectrum), trigger (auto/rising/off) | P1 |
+| **SCOPE** | 12 | native | no | `A` any, `B` any, `TRIG` gate | `A` audio, `B` audio (pass-through) | time 1–500 ms/div, scale 0.1–2, mode (wave/xy/spectrum), trigger level −1…1, slope (rising/falling) | P1 |
+| **METER** | 8 | native | no | `1`–`4` audio | `1`–`4` audio (pass-through) | mode (audio/cv), source (peak/rms) | P1 |
 | **CV MON** | 4 | native | shows ch 1–8 | `IN` any | — | display (volts / semitones / Hz / raw) | P1 |
 | **TUNER** | 6 | native | no | `IN` audio | — | reference A 415–466 Hz | P1 |
 
@@ -145,7 +146,9 @@ Priority: **P0** = required for the first shippable rack, **P1** = same release,
 
 **PARAM OUT.** Control-rate bridge described in §5.7 of the main spec: an `AnalyserNode` on the input is polled at 60 Hz, mapped through `range`, and written via `MixerEngine.setVolume/setPan/setEffectParam`. Panel states "control rate" so nobody expects audio-rate mixer modulation.
 
-**SCOPE / CV MON / TUNER.** All `AnalyserNode` readers on the shared 30 fps poll loop, suspended when the rack view is hidden. `TUNER` uses autocorrelation on a 2048-sample window — accurate enough for tuning a VCO, and it is the fastest way to prove 1 V/oct tracking is correct.
+**SCOPE / METER / CV MON / TUNER.** All `AnalyserNode` readers on the shared 30 fps poll loop, suspended when the rack view is hidden. `TUNER` uses autocorrelation on a 2048-sample window — accurate enough for tuning a VCO, and it is the fastest way to prove 1 V/oct tracking is correct.
+
+**SCOPE and METER are inline, not taps.** An `AnalyserNode` passes its input through unchanged and keeps analysing whether or not its output is patched, so both wire `IN → analyser → OUT` and can sit in the middle of a patch. `SCOPE` triggers on `TRIG` when something is patched there and on `A` otherwise; with no edge found it free-runs and paints `UNTRIG`. `METER`'s `cv` mode is not a dB meter — a control voltage is legitimately a steady, possibly negative DC (0.1 CV = 1 octave, 0.0 = C4), which `abs()` and a −60 dB floor both destroy, so it switches to a bipolar centre-zero scale with a single 30 ms follower and no peak-hold or clip latch.
 
 ---
 

--- a/src/renderer/js/rack/modules/index.js
+++ b/src/renderer/js/rack/modules/index.js
@@ -36,6 +36,7 @@ import slew from './slew.js'
 import sh from './sh.js'
 import comp from './comp.js'
 import scope from './scope.js'
+import meter from './meter.js'
 import cvMon from './cv-mon.js'
 import tuner from './tuner.js'
 import delay from './delay.js'
@@ -51,7 +52,7 @@ import ringmod from './ringmod.js'
 import split from './split.js'
 import merge from './merge.js'
 
-const MODULE_LIST = [vco, noise, vcf, adsr, lfo, vca, mix, att, out, clock, seq8, clkdiv, ad, perc4, rnd, euclid, algo, quant, midiIn, keys, audioIn, paramOut, fmop, drum, fold, slew, sh, comp, scope, cvMon, tuner, delay, drive, math, mult, sum, reverb, chorus, ringmod, split, merge, vc, bus]
+const MODULE_LIST = [vco, noise, vcf, adsr, lfo, vca, mix, att, out, clock, seq8, clkdiv, ad, perc4, rnd, euclid, algo, quant, midiIn, keys, audioIn, paramOut, fmop, drum, fold, slew, sh, comp, scope, meter, cvMon, tuner, delay, drive, math, mult, sum, reverb, chorus, ringmod, split, merge, vc, bus]
 
 export const MODULES = Object.fromEntries(MODULE_LIST.map(m => [m.type, m]))
 

--- a/src/renderer/js/rack/modules/meter.js
+++ b/src/renderer/js/rack/modules/meter.js
@@ -1,0 +1,181 @@
+// METER — four independent level meters, each patched inline.
+//
+// IN n -> analyser (tap) and IN n -> OUT n, in parallel. The analyser must be a
+// leaf: Chrome only renders a subgraph that reaches the destination, and an
+// AnalyserNode escapes that rule via automatic-pull ONLY while it has no
+// outgoing connections. Wiring it inline as IN -> analyser -> OUT disqualifies
+// it, so a meter reads zero whenever its OUT is unpatched — i.e. most of the
+// time. Four small analysers, one per channel; a shared multi-channel node would
+// sum what should stay separate.
+//
+// Two metering laws, because this rack carries both kinds of signal:
+//   audio — dB ladder to a -60 dBFS floor, peak-hold cap, clip latch.
+//   cv    — bipolar centre-zero linear scale. A control voltage legitimately
+//           sits at a steady negative DC (0.1 CV = 1 octave, 0.0 = C4); abs()
+//           kills the sign and a dB floor is meaningless for a valid -0.4 V.
+//
+// create() runs the ballistics on the shared poll; panel() only paints what
+// uiMeters() hands it, the same split algo.js uses.
+
+import { levels, bipolar, dbfs, dbToFraction, approach, peakHold } from '../viz.js'
+
+const FLOOR = -60      // dBFS
+const ATTACK = 0.01    // s
+const RELEASE = 0.3    // s
+const CV_TAU = 0.03    // s
+const CLIP_HOLD = 1.5  // s
+const CHANNELS = 4
+
+export default {
+  type: 'meter',
+  name: 'METER',
+  group: 'io',
+  hp: 8,
+  tier: 'native',
+  poly: false,
+  ports: [
+    ...Array.from({ length: CHANNELS }, (_, i) => ({ id: `in${i + 1}`, dir: 'in', kind: 'audio', label: `${i + 1}` })),
+    ...Array.from({ length: CHANNELS }, (_, i) => ({ id: `out${i + 1}`, dir: 'out', kind: 'audio', label: `${i + 1}` }))
+  ],
+  params: [
+    { key: 'mode', label: 'MODE', options: ['audio', 'cv'], def: 'audio' },
+    { key: 'source', label: 'SRC', options: ['peak', 'rms'], def: 'peak' }
+  ],
+
+  create(ctx, { params = {}, poll = null } = {}) {
+    const chans = Array.from({ length: CHANNELS }, () => {
+      const input = ctx.createGain(), analyser = ctx.createAnalyser(), out = ctx.createGain()
+      analyser.fftSize = 512
+      input.connect(analyser)
+      input.connect(out)
+      return {
+        input, analyser, out,
+        buf: new Float32Array(analyser.fftSize),
+        db: FLOOR, hold: { value: FLOOR, hold: 0 }, clip: 0, cv: 0
+      }
+    })
+
+    // Real elapsed time, not a fixed 1/30 — RackPoll's interval drifts and the
+    // ballistics are defined in seconds.
+    let last = performance.now() / 1000
+    const tick = () => {
+      const t = performance.now() / 1000
+      const dt = Math.min(0.25, Math.max(0, t - last))
+      last = t
+      const cv = params.mode === 'cv'
+      for (const ch of chans) {
+        ch.analyser.getFloatTimeDomainData?.(ch.buf)
+        if (cv) {
+          ch.cv = approach(ch.cv, bipolar(ch.buf).mean, dt, CV_TAU)
+          ch.clip = 0
+          continue
+        }
+        const { peak, rms } = levels(ch.buf)
+        const target = dbfs(params.source === 'rms' ? rms : peak, FLOOR)
+        ch.db = approach(ch.db, target, dt, target > ch.db ? ATTACK : RELEASE)
+        ch.hold = peakHold(ch.hold, dbfs(peak, FLOOR), dt, { floor: FLOOR })
+        ch.clip = peak >= 1 ? CLIP_HOLD : Math.max(0, ch.clip - dt)
+      }
+    }
+    const removePoll = poll?.add(tick)
+
+    const port = (prefix, pick) => Object.fromEntries(chans.map((ch, i) => [`${prefix}${i + 1}`, [pick(ch)]]))
+
+    return {
+      inputs: port('in', ch => ch.input),
+      outputs: port('out', ch => ch.out),
+      analysers: chans.map(ch => ch.analyser),
+      uiMeters: () => chans.map(ch => ({ db: ch.db, hold: ch.hold.value, clip: ch.clip > 0, cv: ch.cv })),
+      setParam(key, value) { params[key] = value },
+      dispose() {
+        removePoll?.()
+        for (const ch of chans) { ch.input.disconnect(); ch.analyser.disconnect(); ch.out.disconnect() }
+      }
+    }
+  },
+
+  panel(module, { params, getInstance, addPoll }) {
+    const wrapper = document.createElement('div')
+    wrapper.className = 'rack-meter'
+    const canvas = document.createElement('canvas')
+    wrapper.append(canvas)
+    const g = context2d(canvas)
+
+    // Self-unregisters once RackView drops the panel — it rebuilds panels
+    // wholesale and never tears them down.
+    const removePoll = addPoll(() => {
+      if (!wrapper.isConnected) { removePoll(); return }
+      const meters = getInstance()?.uiMeters?.()
+      if (!g || !meters) return
+      const { w, h } = fit(canvas, g, 112, 88)
+      if (w < 4 || h < 4) return
+      g.clearRect(0, 0, w, h)
+      const cv = params().mode === 'cv'
+      if (cv) { g.fillStyle = '#ffffff1a'; g.fillRect(0, Math.round(h / 2), w, 1) }
+      else ladder(g, w, h)
+      const slot = w / meters.length
+      const bw = Math.max(3, slot - 4)
+      meters.forEach((m, i) => {
+        const x = i * slot + (slot - bw) / 2
+        if (cv) paintCv(g, x, bw, h, m)
+        else paintDb(g, x, bw, h, m)
+      })
+    })
+
+    return wrapper
+  }
+}
+
+// ─── Canvas plumbing ───
+// jsdom has no 2D context and reports it as a jsdom error rather than a value.
+function context2d(canvas) {
+  try { return canvas.getContext('2d') || null } catch { return null }
+}
+
+// Backing store in device pixels, drawing in CSS pixels — anything less and
+// every edge looks soft on a HiDPI screen.
+function fit(canvas, g, fallbackW, fallbackH) {
+  const dpr = window.devicePixelRatio || 1
+  const w = canvas.clientWidth || fallbackW, h = canvas.clientHeight || fallbackH
+  if (canvas.width !== Math.round(w * dpr) || canvas.height !== Math.round(h * dpr)) {
+    canvas.width = Math.round(w * dpr)
+    canvas.height = Math.round(h * dpr)
+  }
+  g.setTransform(dpr, 0, 0, dpr, 0, 0)
+  return { w, h }
+}
+
+function ladder(g, w, h) {
+  g.fillStyle = '#ffffff14'
+  for (const db of [0, -6, -12, -24, -48]) {
+    g.fillRect(0, Math.round(h - dbToFraction(db, FLOOR) * h), w, 1)
+  }
+}
+
+function paintDb(g, x, bw, h, m) {
+  const fill = dbToFraction(m.db, FLOOR) * h
+  const hot = dbToFraction(-6, FLOOR) * h
+  g.fillStyle = '#6ee07a'
+  g.fillRect(x, h - fill, bw, fill)
+  if (fill > hot) {
+    g.fillStyle = '#ffcf5c'
+    g.fillRect(x, h - fill, bw, fill - hot)
+  }
+  const cap = dbToFraction(m.hold, FLOOR) * h
+  if (cap > 0) {
+    g.fillStyle = '#e8f4ff'
+    g.fillRect(x, Math.max(0, h - cap - 1), bw, 2)
+  }
+  if (m.clip) {
+    g.fillStyle = '#ff5a4d'
+    g.fillRect(x, 0, bw, 3)
+  }
+}
+
+function paintCv(g, x, bw, h, m) {
+  const mid = h / 2
+  const v = Math.max(-1, Math.min(1, m.cv))
+  const span = Math.abs(v) * (mid - 1)
+  g.fillStyle = v < 0 ? '#ffb36b' : '#7ee0ff'
+  g.fillRect(x, v < 0 ? mid : mid - span, bw, Math.max(1, span))
+}

--- a/src/renderer/js/rack/modules/scope.js
+++ b/src/renderer/js/rack/modules/scope.js
@@ -1,2 +1,243 @@
-function analyserModule(type, name, hp, ports, params) { return { type, name, group: 'io', hp, tier: 'native', poly: false, ports, params, create(ctx, { poll = null }) { const inputs = {}, nodes = []; for (const p of ports.filter(p => p.dir === 'in')) { const input = ctx.createGain(), analyser = ctx.createAnalyser(); input.connect(analyser); inputs[p.id] = [input]; nodes.push(input, analyser) } const remove = poll?.add(() => nodes.filter(n => n.getFloatTimeDomainData).forEach(n => n.getFloatTimeDomainData(new Float32Array(n.fftSize)))); return { inputs, outputs: {}, setParam() {}, dispose() { remove?.(); nodes.forEach(n => n.disconnect()) } } } } }
-export default analyserModule('scope', 'SCOPE', 12, [{ id: 'a', dir: 'in', kind: 'audio', label: 'A' }, { id: 'b', dir: 'in', kind: 'audio', label: 'B' }, { id: 'trig', dir: 'in', kind: 'gate', label: 'TRIG' }], [{ key: 'time', label: 'TIME', min: 1, max: 500, step: 1, def: 50, fmt: 'ms' }, { key: 'scale', label: 'SCALE', min: .1, max: 2, step: .1, def: 1, fmt: '' }, { key: 'mode', label: 'MODE', options: ['wave', 'xy', 'spectrum'], def: 'wave' }])
+// SCOPE — dual-trace oscilloscope you can patch through.
+//
+// A -> analyser (tap) and A -> A OUT, in parallel. The analyser must be a leaf:
+// Chrome only renders a subgraph that reaches the destination, and an
+// AnalyserNode escapes that rule via automatic-pull ONLY while it has no
+// outgoing connections. Wiring it inline as A -> analyser -> A OUT disqualifies
+// it, so the trace goes dead the moment nothing is patched into A OUT — which is
+// how a scope gets used most of the time.
+//
+// create() captures and triggers on the shared poll and hands the result to
+// uiFrame(); panel() only paints. Same split as algo.js — the module stays
+// testable with no DOM, and the panel is throwaway.
+
+import { findTrigger, levels, fftSizeFor } from '../viz.js'
+
+const LIVE = 0.01 // peak below this and a jack counts as unpatched
+
+export default {
+  type: 'scope',
+  name: 'SCOPE',
+  group: 'io',
+  hp: 12,
+  tier: 'native',
+  poly: false,
+  ports: [
+    { id: 'a', dir: 'in', kind: 'audio', label: 'A' },
+    { id: 'b', dir: 'in', kind: 'audio', label: 'B' },
+    { id: 'trig', dir: 'in', kind: 'gate', label: 'TRIG' },
+    { id: 'outa', dir: 'out', kind: 'audio', label: 'A' },
+    { id: 'outb', dir: 'out', kind: 'audio', label: 'B' }
+  ],
+  params: [
+    { key: 'time', label: 'TIME', min: 1, max: 500, step: 1, def: 50, fmt: 'ms' },
+    { key: 'scale', label: 'SCALE', min: .1, max: 2, step: .1, def: 1, fmt: '' },
+    { key: 'mode', label: 'MODE', options: ['wave', 'xy', 'spectrum'], def: 'wave' },
+    { key: 'level', label: 'LEVEL', min: -1, max: 1, step: 0.01, def: 0, fmt: '' },
+    { key: 'slope', label: 'SLOPE', options: ['rising', 'falling'], def: 'rising' }
+  ],
+
+  create(ctx, { params = {}, poll = null } = {}) {
+    const chain = (withOut) => {
+      const input = ctx.createGain(), analyser = ctx.createAnalyser()
+      const out = withOut ? ctx.createGain() : null
+      input.connect(analyser)
+      if (out) input.connect(out)
+      return { input, analyser, out }
+    }
+    const a = chain(true), b = chain(true), trig = chain(false)
+
+    // What panel() paints. Buffers are reused, not reallocated per frame — the
+    // panel reads them inside the same poll tick, so sharing is safe.
+    const frame = {
+      mode: 'wave', start: 0, count: 2, triggered: false, bLive: false, bins: 0,
+      a: new Float32Array(0), b: new Float32Array(0), spectrum: new Uint8Array(0)
+    }
+    let trigBuf = new Float32Array(0), size = 0
+
+    const seconds = () => Math.max(0.001, (Number(params.time) || 50) / 1000)
+
+    // Capture twice the display window so findTrigger always has a full window
+    // of samples left behind whatever edge it lands on.
+    const resize = () => {
+      const want = fftSizeFor(seconds() * 2, ctx.sampleRate)
+      if (want === size) return
+      size = want
+      for (const n of [a.analyser, b.analyser, trig.analyser]) n.fftSize = want
+      frame.a = new Float32Array(want)
+      frame.b = new Float32Array(want)
+      frame.spectrum = new Uint8Array(want / 2)
+      trigBuf = new Float32Array(want)
+    }
+    resize()
+
+    const capture = () => {
+      resize()
+      const mode = params.mode || 'wave'
+      frame.mode = mode
+
+      if (mode === 'spectrum') {
+        a.analyser.getByteFrequencyData?.(frame.spectrum)
+        frame.bins = frame.spectrum.length
+        return
+      }
+
+      a.analyser.getFloatTimeDomainData?.(frame.a)
+      b.analyser.getFloatTimeDomainData?.(frame.b)
+      frame.count = Math.max(2, Math.min(Math.round(seconds() * ctx.sampleRate), frame.a.length >> 1))
+      frame.bLive = levels(frame.b).peak > LIVE
+
+      if (mode === 'xy') { frame.start = 0; frame.triggered = true; return }
+
+      // TRIG is a real input, not decoration: if something is patched into it,
+      // it wins over channel A as the trigger source.
+      trig.analyser.getFloatTimeDomainData?.(trigBuf)
+      const source = levels(trigBuf).peak > LIVE ? trigBuf : frame.a
+      const at = findTrigger(source, frame.count, Number(params.level) || 0, params.slope || 'rising')
+      frame.triggered = at >= 0
+      frame.start = at >= 0 ? at : 0
+    }
+    const removePoll = poll?.add(capture)
+
+    return {
+      inputs: { a: [a.input], b: [b.input], trig: [trig.input] },
+      outputs: { outa: [a.out], outb: [b.out] },
+      analysers: { a: a.analyser, b: b.analyser, trig: trig.analyser },
+      uiFrame: () => frame,
+      setParam(key, value) {
+        params[key] = value
+        if (key === 'time') resize()
+      },
+      dispose() {
+        removePoll?.()
+        for (const part of [a, b, trig]) {
+          part.input.disconnect()
+          part.analyser.disconnect()
+          part.out?.disconnect()
+        }
+      }
+    }
+  },
+
+  panel(module, { params, getInstance, addPoll }) {
+    const wrapper = document.createElement('div')
+    wrapper.className = 'rack-scope'
+    const canvas = document.createElement('canvas')
+    wrapper.append(canvas)
+    const g = context2d(canvas)
+
+    // Self-unregisters once RackView drops the panel — it rebuilds panels
+    // wholesale and never tears them down.
+    const removePoll = addPoll(() => {
+      if (!wrapper.isConnected) { removePoll(); return }
+      const frame = getInstance()?.uiFrame?.()
+      if (!g || !frame) return
+      const { w, h } = fit(canvas, g, 176, 96)
+      if (w < 4 || h < 4) return
+      g.clearRect(0, 0, w, h)
+      grid(g, w, h)
+      const scale = Number(params().scale) || 1
+      if (frame.mode === 'spectrum') paintSpectrum(g, w, h, frame)
+      else if (frame.mode === 'xy') paintXY(g, w, h, frame, scale)
+      else paintWave(g, w, h, frame, scale)
+    })
+
+    return wrapper
+  }
+}
+
+// ─── Canvas plumbing ───
+// jsdom has no 2D context and reports it as a jsdom error rather than a value.
+function context2d(canvas) {
+  try { return canvas.getContext('2d') || null } catch { return null }
+}
+
+// Backing store in device pixels, drawing in CSS pixels — anything less and
+// every trace looks soft on a HiDPI screen.
+function fit(canvas, g, fallbackW, fallbackH) {
+  const dpr = window.devicePixelRatio || 1
+  const w = canvas.clientWidth || fallbackW, h = canvas.clientHeight || fallbackH
+  if (canvas.width !== Math.round(w * dpr) || canvas.height !== Math.round(h * dpr)) {
+    canvas.width = Math.round(w * dpr)
+    canvas.height = Math.round(h * dpr)
+  }
+  g.setTransform(dpr, 0, 0, dpr, 0, 0)
+  return { w, h }
+}
+
+function grid(g, w, h) {
+  g.strokeStyle = '#ffffff14'
+  g.lineWidth = 1
+  g.beginPath()
+  for (let i = 1; i < 4; i++) {
+    const x = Math.round(i * w / 4) + .5, y = Math.round(i * h / 4) + .5
+    g.moveTo(x, 0); g.lineTo(x, h)
+    g.moveTo(0, y); g.lineTo(w, y)
+  }
+  g.stroke()
+}
+
+// One column per pixel, min..max within the column. Straight decimation aliases
+// a 500 ms window of audio into moiré; this looks like a scope.
+function trace(g, buf, start, count, w, h, scale, color) {
+  const columns = Math.max(1, Math.min(count, Math.round(w)))
+  const y = v => h / 2 - Math.max(-1, Math.min(1, v * scale)) * (h / 2 - 1)
+  g.strokeStyle = color
+  g.lineWidth = 1
+  g.beginPath()
+  for (let c = 0; c < columns; c++) {
+    const from = Math.floor(c * count / columns)
+    const to = Math.max(from + 1, Math.floor((c + 1) * count / columns))
+    let lo = Infinity, hi = -Infinity
+    for (let i = from; i < to; i++) {
+      const v = buf[start + i] || 0
+      if (v < lo) lo = v
+      if (v > hi) hi = v
+    }
+    const x = columns === 1 ? 0 : c / (columns - 1) * w
+    if (!c) g.moveTo(x, y(hi))
+    else g.lineTo(x, y(hi))
+    g.lineTo(x, y(lo))
+  }
+  g.stroke()
+}
+
+function paintWave(g, w, h, frame, scale) {
+  trace(g, frame.a, frame.start, frame.count, w, h, scale, '#7ee0ff')
+  if (frame.bLive) trace(g, frame.b, frame.start, frame.count, w, h, scale, '#ffb36b')
+  if (!frame.triggered) {
+    g.fillStyle = '#ff9b6b'
+    g.font = '8px monospace'
+    g.fillText('UNTRIG', 3, 9)
+  }
+}
+
+function paintXY(g, w, h, frame, scale) {
+  const step = Math.max(1, Math.floor(frame.count / 1024))
+  const clamp = v => Math.max(-1, Math.min(1, v * scale))
+  g.strokeStyle = '#7ee0ff'
+  g.lineWidth = 1
+  g.beginPath()
+  for (let i = 0; i < frame.count; i += step) {
+    const x = w / 2 + clamp(frame.a[i] || 0) * (w / 2 - 1)
+    const y = h / 2 - clamp(frame.b[i] || 0) * (h / 2 - 1)
+    i ? g.lineTo(x, y) : g.moveTo(x, y)
+  }
+  g.stroke()
+}
+
+function paintSpectrum(g, w, h, frame) {
+  const bins = frame.bins
+  if (!bins) return
+  const columns = Math.max(1, Math.min(bins, Math.round(w)))
+  const bw = w / columns
+  g.fillStyle = '#7ee0ff'
+  for (let c = 0; c < columns; c++) {
+    const from = Math.floor(c * bins / columns)
+    const to = Math.max(from + 1, Math.floor((c + 1) * bins / columns))
+    let peak = 0
+    for (let i = from; i < to; i++) if (frame.spectrum[i] > peak) peak = frame.spectrum[i]
+    const bh = peak / 255 * h
+    g.fillRect(c * bw, h - bh, Math.max(1, bw - 1), bh)
+  }
+}

--- a/src/renderer/js/rack/viz.js
+++ b/src/renderer/js/rack/viz.js
@@ -1,0 +1,111 @@
+/**
+ * viz.js
+ * Pure math for the modular rack's visualization modules (scope, meters).
+ * No DOM, no AudioContext, no globals — callers own the AnalyserNode reads
+ * and the rAF loop; this module only turns sample buffers into numbers.
+ */
+
+// ─── Oscilloscope trigger ───
+// Scans [1, buffer.length - displaySamples) for a level crossing in the
+// requested direction, so the returned index always leaves a full display
+// window behind it. Hysteresis arms the detector: the signal must travel
+// past level-hysteresis (rising) / level+hysteresis (falling) before a
+// crossing counts, otherwise noise dithering on the threshold retriggers
+// every sample instead of locking to one stable edge.
+export function findTrigger(buffer, displaySamples, level = 0, slope = 'rising', hysteresis = 0.02) {
+  const searchEnd = buffer.length - displaySamples
+  const rising = slope !== 'falling'
+  let armed = false
+  for (let i = 1; i < searchEnd; i++) {
+    const prev = buffer[i - 1]
+    const cur = buffer[i]
+    if (rising) {
+      if (!armed) {
+        if (prev < level - hysteresis) armed = true
+        continue
+      }
+      if (prev < level && cur >= level) return i
+    } else {
+      if (!armed) {
+        if (prev > level + hysteresis) armed = true
+        continue
+      }
+      if (prev > level && cur <= level) return i
+    }
+  }
+  return -1
+}
+
+// ─── Levels ───
+export function levels(buffer) {
+  let peak = 0
+  let sumSquares = 0
+  for (let i = 0; i < buffer.length; i++) {
+    const v = buffer[i]
+    const a = Math.abs(v)
+    if (a > peak) peak = a
+    sumSquares += v * v
+  }
+  return { peak, rms: buffer.length ? Math.sqrt(sumSquares / buffer.length) : 0 }
+}
+
+// Signed extremes and mean — CV is valid at a steady negative DC, which
+// abs()/dB metering destroys.
+export function bipolar(buffer) {
+  if (!buffer.length) return { min: 0, max: 0, mean: 0 }
+  let min = buffer[0]
+  let max = buffer[0]
+  let sum = 0
+  for (let i = 0; i < buffer.length; i++) {
+    const v = buffer[i]
+    if (v < min) min = v
+    if (v > max) max = v
+    sum += v
+  }
+  return { min, max, mean: sum / buffer.length }
+}
+
+// ─── dB scaling ───
+// dbfs(0) === floor, never -Infinity: log10(0) is guarded by an epsilon
+// below any sane floor, then the result is clamped to floor anyway.
+export function dbfs(amplitude, floor = -60) {
+  const db = 20 * Math.log10(Math.max(Math.abs(amplitude), 1e-10))
+  return Math.max(db, floor)
+}
+
+export function dbToFraction(db, floor = -60) {
+  const clamped = Math.min(0, Math.max(floor, db))
+  return (clamped - floor) / -floor
+}
+
+// ─── Ballistics ───
+// Frame-rate independent exponential approach: alpha = 1 - exp(-dt/tau).
+// A fixed per-frame multiplier is wrong because it implies a different
+// real-world time constant at every frame rate; this form doesn't.
+export function approach(current, target, dt, tau) {
+  if (tau <= 0 || dt <= 0) return target
+  const alpha = 1 - Math.exp(-dt / tau)
+  return current + (target - current) * alpha
+}
+
+// Peak-hold cap state machine, in dB. Snaps up instantly to any higher
+// target, holds flat for holdSeconds, then decays toward floor.
+export function peakHold(state, targetDb, dt, { holdSeconds = 1.5, decayTau = 0.5, floor = -60 } = {}) {
+  if (targetDb >= state.value) {
+    return { value: targetDb, hold: holdSeconds }
+  }
+  if (state.hold > 0) {
+    return { value: state.value, hold: state.hold - dt }
+  }
+  return { value: approach(state.value, floor, dt, decayTau), hold: 0 }
+}
+
+// ─── AnalyserNode sizing ───
+// Smallest power-of-two fftSize whose window (fftSize / sampleRate) covers
+// windowSeconds, clamped to the AnalyserNode legal range [32, 32768].
+export function fftSizeFor(windowSeconds, sampleRate) {
+  const needed = Math.max(1, windowSeconds * sampleRate)
+  let size = 32
+  while (size < needed && size < 32768) size *= 2
+  return size
+}

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -242,6 +242,15 @@ html, body {
    reads on top of an .on cell without hiding whether the step is armed. */
 .algo-cell.at { border-color: #fff; box-shadow: 0 0 6px 1px #ffffffb0, inset 0 0 4px #ffffff40; }
 
+/* SCOPE and METER paint a canvas. Only the box is styled here — the panel's poll
+   job sizes the backing store by devicePixelRatio and draws in CSS pixels. The
+   wrapper takes the panel's slack so the screen grows with the rail height. */
+.rack-scope, .rack-meter { flex: 1 1 auto; min-height: 60px; margin-top: 4px; display: flex; }
+.rack-scope canvas, .rack-meter canvas {
+  flex: 1 1 auto; width: 100%; height: 100%;
+  background: #0d1114; border: 1px solid #59616c; border-radius: 2px;
+}
+
 .rack-jack-slot { display: flex; flex-direction: column; align-items: center; width: 22px; gap: 1px; }
 .rack-jack-slot em {
   font-style: normal; font-size: 7px; line-height: 1; letter-spacing: 0;

--- a/tests/rack-viz-modules.test.js
+++ b/tests/rack-viz-modules.test.js
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import scope from '../src/renderer/js/rack/modules/scope.js'
+import meter from '../src/renderer/js/rack/modules/meter.js'
+import { paramDefaults } from '../src/renderer/js/rack/modules/index.js'
+import { RackPoll } from '../src/renderer/js/rack/rack-poll.js'
+import { renderPanel } from '../src/renderer/js/components/rack-panel.js'
+
+// ---------------------------------------------------------------------------
+// Minimal BaseAudioContext fake. `read` is what every analyser hands back; pass
+// nothing and the analysers have no read methods at all — which is exactly the
+// shape of the fake in rack-modules.test.js and the crash that guard prevents.
+// ---------------------------------------------------------------------------
+function makeCtx(read = null) {
+  const created = []
+  const node = (kind, extra = {}) => {
+    const n = {
+      kind, targets: [], disconnected: 0,
+      connect: vi.fn(dst => { n.targets.push(dst); return dst }),
+      disconnect: vi.fn(() => { n.disconnected++ }),
+      ...extra
+    }
+    created.push(n)
+    return n
+  }
+  return {
+    currentTime: 0, sampleRate: 44100, created,
+    createGain: () => node('gain', { gain: { value: 1, setValueAtTime: vi.fn(), setTargetAtTime: vi.fn() } }),
+    createAnalyser: () => {
+      const n = node('analyser', { fftSize: 2048 })
+      if (read) {
+        n.getFloatTimeDomainData = buf => { for (let i = 0; i < buf.length; i++) buf[i] = read(i, buf.length) }
+        n.getByteFrequencyData = buf => buf.fill(200)
+      }
+      return n
+    }
+  }
+}
+
+const reaches = (from, to) => !!from?.targets?.some(n => n === to || reaches(n, to))
+const build = (def, ctx, poll = null, params = {}) =>
+  def.create(ctx, { params: { ...paramDefaults(def.type), ...params }, poll })
+
+// jsdom ships no 2D context, so the paint path would never run. A recording fake
+// runs it for real and fails on any method the modules assume but a canvas lacks.
+function fake2d() {
+  const g = { calls: [] }
+  for (const fn of ['clearRect', 'beginPath', 'moveTo', 'lineTo', 'stroke', 'fill', 'fillRect', 'fillText', 'setTransform', 'save', 'restore']) {
+    g[fn] = vi.fn((...args) => g.calls.push([fn, ...args]))
+  }
+  return g
+}
+
+describe('SCOPE and METER — inline visualization modules', () => {
+  let g2d, originalGetContext
+
+  beforeEach(() => {
+    g2d = fake2d()
+    originalGetContext = HTMLCanvasElement.prototype.getContext
+    HTMLCanvasElement.prototype.getContext = () => g2d
+  })
+  afterEach(() => {
+    HTMLCanvasElement.prototype.getContext = originalGetContext
+    vi.restoreAllMocks()
+  })
+
+  it('exposes every declared port, one channel each, inputs and outputs', () => {
+    for (const def of [scope, meter]) {
+      const inst = build(def, makeCtx())
+      expect(def.ports.some(p => p.dir === 'out'), `${def.type} must be patchable onward`).toBe(true)
+      for (const port of def.ports) {
+        const bag = port.dir === 'in' ? inst.inputs : inst.outputs
+        expect(bag[port.id], `${def.type}.${port.id} missing`).toBeTruthy()
+        expect(bag[port.id].length, `${def.type}.${port.id} is mono`).toBe(1)
+      }
+      inst.dispose()
+    }
+  })
+
+  // Chrome only renders a subgraph that reaches the destination. An AnalyserNode
+  // is exempt via automatic-pull, but ONLY while it has no outgoing connections.
+  // Wiring it inline (in -> analyser -> out) forfeits that exemption, and the
+  // module reads silence whenever its OUT jack is unpatched — which is how a
+  // scope or meter is used most of the time. So: tap in parallel, never inline.
+  it('taps with a leaf analyser and passes through in parallel', () => {
+    const isLeaf = node => node.kind === 'analyser' && node.targets.length === 0
+
+    const s = build(scope, makeCtx())
+    for (const port of ['a', 'b']) {
+      const kinds = s.inputs[port][0].targets.map(n => n.kind).sort()
+      expect(kinds, `scope.${port} fans out to tap + pass-through`).toEqual(['analyser', 'gain'])
+      expect(s.inputs[port][0].targets.filter(isLeaf).length, `scope.${port} analyser is a leaf`).toBe(1)
+    }
+    expect(reaches(s.inputs.a[0], s.outputs.outa[0])).toBe(true)
+    expect(reaches(s.inputs.b[0], s.outputs.outb[0])).toBe(true)
+    // A and B stay separate traces, not a summed one.
+    expect(reaches(s.inputs.a[0], s.outputs.outb[0])).toBe(false)
+    // TRIG is a tap only — no pass-through jack, so a lone leaf analyser.
+    expect(s.inputs.trig[0].targets.every(isLeaf)).toBe(true)
+    s.dispose()
+
+    const m = build(meter, makeCtx())
+    for (let i = 1; i <= 4; i++) {
+      const kinds = m.inputs[`in${i}`][0].targets.map(n => n.kind).sort()
+      expect(kinds, `meter ch${i} fans out to tap + pass-through`).toEqual(['analyser', 'gain'])
+      expect(m.inputs[`in${i}`][0].targets.filter(isLeaf).length, `meter ch${i} analyser is a leaf`).toBe(1)
+      expect(reaches(m.inputs[`in${i}`][0], m.outputs[`out${i}`][0]), `meter ch${i} pass-through`).toBe(true)
+    }
+    expect(reaches(m.inputs.in1[0], m.outputs.out2[0])).toBe(false)
+    m.dispose()
+  })
+
+  it('METER meters four channels on four separate analysers', () => {
+    const ctx = makeCtx()
+    const m = build(meter, ctx)
+    expect(m.analysers).toHaveLength(4)
+    expect(new Set(m.analysers).size).toBe(4)
+    m.dispose()
+  })
+
+  it('dispose() removes its poll job and disconnects everything it built', () => {
+    for (const def of [scope, meter]) {
+      const ctx = makeCtx(), poll = new RackPoll()
+      const inst = build(def, ctx, poll)
+      expect(poll.jobs.size, `${def.type} registers one poll job`).toBe(1)
+      inst.dispose()
+      expect(poll.jobs.size, `${def.type} leaves no poll job`).toBe(0)
+      expect(ctx.created.filter(n => !n.disconnected).map(n => n.kind)).toEqual([])
+    }
+  })
+
+  it('panel() renders a canvas and adds exactly one more poll job', () => {
+    for (const def of [scope, meter]) {
+      const poll = new RackPoll()
+      const inst = build(def, makeCtx(() => 0.5), poll)
+      const el = renderPanel({ id: `${def.type}-1`, type: def.type, params: {} }, {
+        getInstance: () => inst,
+        addPoll: job => poll.add(job)
+      })
+      expect(el.querySelector('canvas'), `${def.type} panel canvas`).toBeTruthy()
+      expect(poll.jobs.size, `${def.type}: capture job + paint job`).toBe(2)
+
+      // Off the DOM the paint job unregisters itself — RackView rebuilds panels
+      // wholesale and never tears them down.
+      poll.jobs.forEach(job => job())
+      expect(poll.jobs.size).toBe(1)
+      inst.dispose()
+    }
+  })
+
+  it('paints once the panel is on the DOM, at devicePixelRatio', () => {
+    const poll = new RackPoll()
+    const inst = build(scope, makeCtx((i) => Math.sin(i / 64 * 2 * Math.PI)), poll)
+    const el = renderPanel({ id: 's1', type: 'scope', params: {} }, { getInstance: () => inst, addPoll: job => poll.add(job) })
+    document.body.append(el)
+    poll.jobs.forEach(job => job())
+    expect(poll.jobs.size).toBe(2)
+    expect(g2d.setTransform).toHaveBeenCalled()
+    expect(g2d.stroke).toHaveBeenCalled()
+    el.remove()
+    inst.dispose()
+  })
+
+  it('survives a tick against an analyser with no read methods at all', () => {
+    const poll = new RackPoll()
+    const panels = []
+    for (const def of [scope, meter]) {
+      const inst = build(def, makeCtx(), poll)
+      const el = renderPanel({ id: `${def.type}-1`, type: def.type, params: {} }, { getInstance: () => inst, addPoll: job => poll.add(job) })
+      document.body.append(el)
+      panels.push(el)
+    }
+    expect(poll.jobs.size).toBe(4)
+    expect(() => poll.jobs.forEach(job => job())).not.toThrow()
+    expect(poll.jobs.size).toBe(4)
+    panels.forEach(el => el.remove())
+  })
+
+  it('every SCOPE mode paints without a mode-specific crash', () => {
+    for (const mode of ['wave', 'xy', 'spectrum']) {
+      const poll = new RackPoll()
+      const inst = build(scope, makeCtx(i => Math.sin(i / 64 * 2 * Math.PI)), poll, { mode })
+      const el = renderPanel({ id: 's1', type: 'scope', params: { mode } }, { getInstance: () => inst, addPoll: job => poll.add(job) })
+      document.body.append(el)
+      expect(() => poll.jobs.forEach(job => job())).not.toThrow()
+      expect(inst.uiFrame().mode).toBe(mode)
+      el.remove()
+      inst.dispose()
+    }
+  })
+
+  it('SCOPE triggers on a waveform and flags UNTRIG on a flat line', () => {
+    const poll = new RackPoll()
+    const wave = build(scope, makeCtx(i => Math.sin(i / 64 * 2 * Math.PI)), poll, { time: 1 })
+    poll.jobs.forEach(job => job())
+    expect(wave.uiFrame().triggered).toBe(true)
+    expect(wave.uiFrame().count).toBeGreaterThan(1)
+    wave.dispose()
+
+    const quiet = new RackPoll()
+    const flat = build(scope, makeCtx(() => 0), quiet)
+    quiet.jobs.forEach(job => job())
+    expect(flat.uiFrame().triggered).toBe(false)
+    expect(flat.uiFrame().start).toBe(0)
+    flat.dispose()
+  })
+
+  it('SCOPE triggers on TRIG when something is patched there, not on A', () => {
+    const poll = new RackPoll()
+    const inst = build(scope, makeCtx(() => 0), poll, { time: 1 })
+    poll.jobs.forEach(job => job())
+    expect(inst.uiFrame().triggered).toBe(false)
+
+    // A is still flat; only TRIG carries an edge. A decorative TRIG jack would
+    // leave this free-running.
+    inst.analysers.trig.getFloatTimeDomainData = buf => { buf.fill(-0.5); buf.fill(1, 20) }
+    poll.jobs.forEach(job => job())
+    const frame = inst.uiFrame()
+    expect(frame.triggered).toBe(true)
+    expect(frame.start).toBeGreaterThan(0)
+    expect(frame.start).toBeLessThanOrEqual(21)
+    inst.dispose()
+  })
+
+  it('METER latches clip and holds the peak cap above the falling bar', () => {
+    const level = { v: 1 }
+    const clock = { t: 0 }
+    vi.spyOn(performance, 'now').mockImplementation(() => clock.t * 1000)
+    const poll = new RackPoll()
+    const inst = build(meter, makeCtx(() => level.v), poll)
+    const run = seconds => {
+      for (let i = 0; i < Math.round(seconds * 30); i++) { clock.t += 1 / 30; poll.jobs.forEach(job => job()) }
+    }
+
+    run(0.5)
+    expect(inst.uiMeters()[0].clip).toBe(true)
+    expect(inst.uiMeters()[0].db).toBeGreaterThan(-1)
+
+    level.v = 0
+    run(0.5)
+    const falling = inst.uiMeters()[0]
+    expect(falling.clip, 'clip stays latched for ~1.5 s').toBe(true)
+    expect(falling.hold, 'peak cap sits above the released bar').toBeGreaterThan(falling.db)
+    expect(falling.db).toBeLessThan(-3)
+
+    run(1.5)
+    const settled = inst.uiMeters()[0]
+    expect(settled.clip).toBe(false)
+    expect(settled.db).toBeLessThan(-40)
+    inst.dispose()
+  })
+
+  it('METER cv mode shows a signed voltage instead of dB, with no clip latch', () => {
+    const clock = { t: 0 }
+    vi.spyOn(performance, 'now').mockImplementation(() => clock.t * 1000)
+    const poll = new RackPoll()
+    // -0.25 CV is a valid note 2.5 octaves below C4 — dB metering would read it
+    // as a loud positive signal.
+    const inst = build(meter, makeCtx(() => -0.25), poll, { mode: 'cv' })
+    for (let i = 0; i < 15; i++) { clock.t += 1 / 30; poll.jobs.forEach(job => job()) }
+    const m = inst.uiMeters()[0]
+    expect(m.cv).toBeCloseTo(-0.25, 2)
+    expect(m.clip).toBe(false)
+    inst.dispose()
+  })
+})

--- a/tests/rack-viz.test.js
+++ b/tests/rack-viz.test.js
@@ -1,0 +1,235 @@
+import { describe, it, expect } from 'vitest'
+import {
+  findTrigger, levels, bipolar, dbfs, dbToFraction, approach, peakHold, fftSizeFor
+} from '../src/renderer/js/rack/viz.js'
+
+function makeSine(length, period, phase = 0, amp = 1) {
+  const buf = new Array(length)
+  for (let i = 0; i < length; i++) buf[i] = amp * Math.sin((2 * Math.PI * i) / period + phase)
+  return buf
+}
+
+describe('findTrigger', () => {
+  it('locks a sine to a stable rising zero crossing', () => {
+    const buf = makeSine(1000, 100)
+    const displaySamples = 200
+    const idx = findTrigger(buf, displaySamples)
+    expect(idx).toBeGreaterThan(0)
+    expect(buf[idx - 1]).toBeLessThan(0)
+    expect(buf[idx]).toBeGreaterThanOrEqual(0)
+  })
+
+  it('locks a phase-shifted copy of the same wave to the same phase', () => {
+    const period = 100
+    const displaySamples = 200
+    const bufA = makeSine(1000, period)
+    const bufB = makeSine(1000, period, 1.7) // arbitrary phase offset
+    const idxA = findTrigger(bufA, displaySamples)
+    const idxB = findTrigger(bufB, displaySamples)
+    expect(idxA).toBeGreaterThan(-1)
+    expect(idxB).toBeGreaterThan(-1)
+    // both windows start at the same point in the waveform's cycle, up to
+    // one sample's worth of quantization in where each buffer's discrete
+    // samples happened to land relative to the true zero crossing
+    const sampleStep = (2 * Math.PI) / period
+    for (let k = 0; k < displaySamples; k += 17) {
+      expect(Math.abs(bufA[idxA + k] - bufB[idxB + k])).toBeLessThan(sampleStep)
+    }
+  })
+
+  it('returns -1 for DC', () => {
+    const buf = new Array(1000).fill(0.5)
+    expect(findTrigger(buf, 200)).toBe(-1)
+  })
+
+  it('returns -1 for silence', () => {
+    const buf = new Array(1000).fill(0)
+    expect(findTrigger(buf, 200)).toBe(-1)
+  })
+
+  it('returns -1 when the signal never crosses the level in the requested direction', () => {
+    // dips once, then stays negative for the rest of the buffer — no rising
+    // crossing back through 0 ever occurs
+    const buf = new Array(1000).fill(0.1)
+    for (let i = 200; i < 1000; i++) buf[i] = -0.5
+    expect(findTrigger(buf, 200)).toBe(-1)
+  })
+
+  it('respects slope: falling', () => {
+    const buf = makeSine(1000, 100)
+    const displaySamples = 200
+    const idx = findTrigger(buf, displaySamples, 0, 'falling')
+    expect(idx).toBeGreaterThan(-1)
+    expect(buf[idx - 1]).toBeGreaterThan(0)
+    expect(buf[idx]).toBeLessThanOrEqual(0)
+  })
+
+  it('hysteresis: dithering around the level does not arm the detector', () => {
+    // small wiggle around 0, never dropping below level - hysteresis (-0.02)
+    const buf = new Array(500)
+    for (let i = 0; i < buf.length; i++) buf[i] = i % 2 === 0 ? 0.01 : -0.01
+    expect(findTrigger(buf, 100)).toBe(-1)
+  })
+
+  it('hysteresis: only the crossing after a real arming dip is reported, not earlier dither', () => {
+    const buf = new Array(600)
+    // dither for the first 300 samples — crosses 0 repeatedly but never arms
+    for (let i = 0; i < 300; i++) buf[i] = i % 2 === 0 ? 0.01 : -0.01
+    // then a real dip well past the hysteresis band, followed by a rise
+    for (let i = 300; i < 400; i++) buf[i] = -0.5
+    for (let i = 400; i < 600; i++) buf[i] = 0.5
+    const idx = findTrigger(buf, 100)
+    expect(idx).toBeGreaterThanOrEqual(400)
+    expect(idx).toBeLessThan(600 - 100)
+  })
+
+  it('never returns an index that would run the display window off the end of the buffer', () => {
+    const buf = makeSine(1000, 30) // high frequency, many candidate crossings
+    const displaySamples = 200
+    const idx = findTrigger(buf, displaySamples)
+    if (idx !== -1) expect(idx + displaySamples).toBeLessThanOrEqual(buf.length)
+  })
+
+  it('returns -1 when displaySamples leaves no room to search', () => {
+    const buf = makeSine(50, 10)
+    expect(findTrigger(buf, 200)).toBe(-1)
+  })
+})
+
+describe('levels', () => {
+  it('full-scale square: rms === peak === 1', () => {
+    const buf = new Array(100)
+    for (let i = 0; i < buf.length; i++) buf[i] = i % 2 === 0 ? 1 : -1
+    const { peak, rms } = levels(buf)
+    expect(peak).toBe(1)
+    expect(rms).toBe(1)
+  })
+
+  it('sine of amplitude a: rms ~= a / sqrt(2)', () => {
+    const a = 0.7
+    const buf = makeSine(1000, 100, 0, a) // 10 full periods
+    const { peak, rms } = levels(buf)
+    expect(peak).toBeCloseTo(a, 2)
+    expect(rms).toBeCloseTo(a / Math.SQRT2, 2)
+  })
+})
+
+describe('bipolar', () => {
+  it('reports signed extremes and mean for a steady negative DC signal', () => {
+    const buf = new Array(50).fill(-0.3)
+    const { min, max, mean } = bipolar(buf)
+    expect(min).toBe(-0.3)
+    expect(max).toBe(-0.3)
+    expect(mean).toBeCloseTo(-0.3, 10)
+  })
+
+  it('reports min/max/mean for a mixed signal', () => {
+    const buf = [-1, 0, 1, 0.5, -0.5]
+    const { min, max, mean } = bipolar(buf)
+    expect(min).toBe(-1)
+    expect(max).toBe(1)
+    expect(mean).toBeCloseTo(0, 10)
+  })
+})
+
+describe('dbfs', () => {
+  it('dbfs(1) === 0', () => {
+    expect(dbfs(1)).toBe(0)
+  })
+  it('dbfs(0) === floor, not -Infinity', () => {
+    expect(dbfs(0)).toBe(-60)
+    expect(dbfs(0, -72)).toBe(-72)
+  })
+  it('dbfs(0.5) ~= -6.02', () => {
+    expect(dbfs(0.5)).toBeCloseTo(-6.02, 2)
+  })
+})
+
+describe('dbToFraction', () => {
+  it('dbToFraction(0) === 1, dbToFraction(floor) === 0', () => {
+    expect(dbToFraction(0)).toBe(1)
+    expect(dbToFraction(-60)).toBe(0)
+  })
+  it('clamps above 0 and below floor', () => {
+    expect(dbToFraction(10)).toBe(1)
+    expect(dbToFraction(-1000)).toBe(0)
+  })
+})
+
+describe('approach', () => {
+  it('is frame-rate independent: one big step === many small steps', () => {
+    const tau = 0.1
+    const oneStep = approach(0, 1, 0.1, tau)
+    let manySteps = 0
+    for (let i = 0; i < 10; i++) manySteps = approach(manySteps, 1, 0.01, tau)
+    expect(manySteps).toBeCloseTo(oneStep, 9)
+  })
+  it('snaps to target when tau <= 0 or dt <= 0', () => {
+    expect(approach(0, 5, 0.1, 0)).toBe(5)
+    expect(approach(0, 5, 0.1, -1)).toBe(5)
+    expect(approach(0, 5, 0, 1)).toBe(5)
+    expect(approach(0, 5, -1, 1)).toBe(5)
+  })
+})
+
+describe('peakHold', () => {
+  it('snaps up instantly to a higher target', () => {
+    const state = { value: -60, hold: 0 }
+    const next = peakHold(state, -10, 0.016)
+    expect(next.value).toBe(-10)
+    expect(next.hold).toBe(1.5)
+  })
+
+  it('holds flat across the hold window, then decays', () => {
+    let state = { value: -10, hold: 1.5 }
+    // lower target arrives, but we're inside the hold window
+    state = peakHold(state, -40, 1.0, { holdSeconds: 1.5, decayTau: 0.5, floor: -60 })
+    expect(state.value).toBe(-10)
+    expect(state.hold).toBeCloseTo(0.5, 10)
+
+    // still inside the (now shorter) hold window
+    state = peakHold(state, -40, 0.4, { holdSeconds: 1.5, decayTau: 0.5, floor: -60 })
+    expect(state.value).toBe(-10)
+    expect(state.hold).toBeCloseTo(0.1, 10)
+
+    // this frame's dt pushes hold negative, but decay only starts once
+    // hold is already <= 0 at the *start* of a frame
+    state = peakHold(state, -40, 0.2, { holdSeconds: 1.5, decayTau: 0.5, floor: -60 })
+    expect(state.value).toBe(-10)
+    expect(state.hold).toBeCloseTo(-0.1, 10)
+
+    // hold is now <= 0 going in — decay begins
+    state = peakHold(state, -40, 0.1, { holdSeconds: 1.5, decayTau: 0.5, floor: -60 })
+    expect(state.value).toBeLessThan(-10)
+  })
+
+  it('does not mutate the state object passed in', () => {
+    const state = { value: -10, hold: 1.5 }
+    const snapshot = { ...state }
+    peakHold(state, -40, 1.0)
+    expect(state).toEqual(snapshot)
+  })
+})
+
+describe('fftSizeFor', () => {
+  it('returns a power of two', () => {
+    for (const win of [0.001, 0.01, 0.1, 0.5, 1]) {
+      const size = fftSizeFor(win, 48000)
+      expect(Number.isInteger(Math.log2(size))).toBe(true)
+    }
+  })
+
+  it('clamps to [32, 32768]', () => {
+    expect(fftSizeFor(0, 48000)).toBe(32)
+    expect(fftSizeFor(0.00001, 48000)).toBe(32)
+    expect(fftSizeFor(10, 48000)).toBe(32768)
+  })
+
+  it('covers the requested window when not clamped at the ceiling', () => {
+    const windowSeconds = 0.01
+    const sampleRate = 48000
+    const size = fftSizeFor(windowSeconds, sampleRate)
+    expect(size / sampleRate).toBeGreaterThanOrEqual(windowSeconds)
+    expect(size).toBe(512)
+  })
+})


### PR DESCRIPTION
Signal visualization in the modular rack: an oscilloscope you can patch through, and four metered in/out pairs.

## What was there

`scope.js` was **registered but hollow** — it built an `AnalyserNode` per input, polled it, threw the samples away, and had no `panel()`. `cv-mon.js` and `tuner.js` are still that same shell. Nothing under `rack/` painted a canvas at all, and no meter module existed.

## New

**`rack/viz.js`** — pure maths, no DOM and no AudioContext, so it is directly testable: rising/falling edge trigger search with hysteresis, peak/RMS, bipolar min/max/mean, dBFS with a floor, frame-rate-independent `approach()`, a peak-hold state machine, `fftSizeFor()`.

**SCOPE** (12 HP, ports unchanged + `outa`/`outb` added)

| Param | Range | Default |
|---|---|---|
| `time` | 1–500 ms | 50 |
| `scale` | 0.1–2 | 1 |
| `mode` | wave / xy / spectrum | wave |
| `level` | −1–1 | 0 |
| `slope` | rising / falling | rising |

Real trace with a proper trigger, so a waveform stands still instead of smearing; free-runs and paints `UNTRIG` when no edge is found. `TRIG` is now a real input — patch it and it wins over channel A as the trigger source. All three declared `mode` options work; a declared-but-dead `spectrum` was part of the same hollowness. Existing port and param ids are unchanged so saved patches survive.

**METER** (8 HP, `in1..in4` / `out1..out4`) — four independent channels, each an inline in/out pair, four separate 512-point analysers. Audio mode: −60 dBFS ladder, 10 ms/300 ms ballistics, 1.5 s peak-hold cap, 1.5 s clip latch at ≥0 dBFS. CV mode: bipolar centre-zero linear scale, 30 ms follower, no hold or clip — this rack is 1 V/oct, so a pitch CV legitimately rests at a steady negative DC that `abs()` and a −60 dB floor would both destroy.

## The bug worth reading

Both modules **tap in parallel** (`in → analyser`, `in → out`) rather than inline (`in → analyser → out`).

Chrome only renders a subgraph that reaches the destination. An `AnalyserNode` escapes that rule via automatic-pull — but **only while it has no outgoing connections**. Wiring it inline for pass-through forfeits the exemption, so the display went blank whenever the OUT jack was unpatched, which is how a scope or meter gets used most of the time. It reproduced only in a real browser; every fake-context test passed against the broken topology. The tests now assert the analyser is a leaf.

## Other decisions

- Painting runs on RackView's existing 30 Hz `RackPoll`, already started and stopped with rack visibility — not a new `requestAnimationFrame` loop, which would keep running while the rack is hidden. Ballistics take `dt` from `performance.now()` because that interval drifts.
- `create()` runs capture and ballistics; `panel()` only paints. Same split as `algo.js`, which keeps the clip latch and peak-hold testable with no DOM.

## Verification

652 tests pass (613 pre-existing + 39 new). Browser-verified with **every scope and meter output deliberately dead-ended** — the case that was broken: dual trace paints both channels, meters show bars with peak-hold caps, CV mode draws bipolar around centre. Trigger lock confirmed by two independent captures landing on identical phase.

Not covered: appearance is pixel-sampled, not diffed against a reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMqb76wkSpNtRu7Uizw6oA