### PR TITLE
fix(rack): SCOPE controls to a side column, so its output jacks fit

### DIFF
--- a/src/renderer/js/components/rack-panel.js
+++ b/src/renderer/js/components/rack-panel.js
@@ -16,6 +16,7 @@ export function renderPanel(module, { onParam, onJack, onEvent, getParams, getIn
   if (def.panel && !def.dock) body.classList.add('rack-params-compact')
   el.append(body)
   const params = { ...paramDefaults(module.type), ...module.params }
+  let knobs = 0
   for (const param of def.params) {
     // Structured params (seq8 steps, drum patterns) have no scalar control —
     // a range input over an array is worse than showing nothing.
@@ -34,8 +35,10 @@ export function renderPanel(module, { onParam, onJack, onEvent, getParams, getIn
     }
     input.dataset.param = param.key
     input.addEventListener('input', () => onParam?.(module.id, param.key, input.type === 'checkbox' ? input.checked : (param.options ? input.value : Number(input.value))))
-    // A docked panel has width but little height: knobs in a row, not stacked sliders.
-    if ((def.dock || def.util) && input.type === 'range') { body.append(renderKnob(param, input)); continue }
+    // Panels with width but little height take knobs, not stacked full-width
+    // sliders: docked and util rows are short by construction, and a panel that
+    // draws needs its height for the drawing.
+    if ((def.dock || def.util || def.panel) && input.type === 'range') { body.append(renderKnob(param, input)); knobs++; continue }
     label.append(input); body.append(label)
   }
   const custom = def.panel?.(module, {
@@ -56,6 +59,11 @@ export function renderPanel(module, { onParam, onJack, onEvent, getParams, getIn
   if (custom) {
     el.append(custom)
     if (custom.refresh) { el.__refresh = custom.refresh; el.addEventListener('input', custom.refresh) }
+    // Knobs stacked above a drawing still eat the height it needs — SCOPE's
+    // output jacks fell off the bottom of the panel. Move them into a column
+    // down the right instead. Only when there are knobs to move: a panel whose
+    // controls are all selects (METER) keeps the full width for its display.
+    if (knobs && !def.dock && !def.util) el.classList.add('rack-panel-side')
   }
   // Inputs and outputs get their own labelled block, the way a real panel is silk-screened.
   // A module may declare its own jack rows (`port.row`) instead of the default

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -226,6 +226,28 @@ html, body {
 .rack-params-compact { flex: 0 0 auto; display: flex; flex-wrap: wrap; gap: 4px 6px; overflow: visible; }
 .rack-params-compact label { flex: 1 1 64px; margin: 0; }
 
+/* A drawing panel whose controls include knobs stands them in a column down the
+   right, with the display taking the rest of the width. Stacked across the top
+   they wrapped to three rows and pushed the output jacks clean off the bottom of
+   the 216px panel. Jack rows still span the full width, under both columns. */
+.rack-panel-side {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--side-col, 58px);
+  grid-template-rows: auto minmax(0, 1fr);
+  column-gap: 6px;
+  align-content: start;
+}
+.rack-panel-side > header { grid-column: 1 / -1; }
+.rack-panel-side > .rack-params {
+  grid-column: 2; grid-row: 2;
+  flex-direction: column; flex-wrap: nowrap; align-items: center; gap: 5px;
+}
+.rack-panel-side > .rack-scope,
+.rack-panel-side > .rack-meter { grid-column: 1; grid-row: 2; margin-top: 0; }
+.rack-panel-side > .rack-jacks { grid-column: 1 / -1; }
+.rack-panel-side .knob { width: 100%; gap: 1px; }
+.rack-panel-side .rack-params label { width: 100%; margin: 0; text-align: center; }
+
 /* One row of 8 steps for the lane the selector points at — eight stacked rows
    was unreadable at 20 HP, and only one lane is ever being edited. */
 .algo-seq { margin-top: 4px; display: flex; flex-direction: column; gap: 5px; }


### PR DESCRIPTION
SCOPE's five params rendered as full-width stacked sliders and selects. At 12 HP they wrapped to three rows, ate the height the display needed, and pushed the A/B **output jacks off the bottom of the 216px panel** — you couldn't patch them.

## Changes

- **Knobs now cover any panel that draws**, not just docked and util rows. Those already took knobs because they're short by construction; a drawing panel has the same problem for the same reason. SCOPE is the only module this reaches — ALGO and METER declare no range params, KEYS is docked already.
- **A drawing panel that has knobs lays out as a grid**: controls in a column down the right, display taking the rest of the width, jack rows spanning both columns underneath. Gated on there actually being knobs to move, so METER (selects only) keeps its full width for the four bars.

## Verified in the browser

| | Before | After |
|---|---|---|
| SCOPE output jacks | hanging off the panel | inside, 11px clearance |
| SCOPE display | 176 × 58 | 114 × 120 |
| METER layout | — | unchanged, full width |

Both traces still draw after the resize. 652 tests pass.

Trade-off worth naming: the display is narrower than it was — about twice the area overall, but less room on the time axis. If that bites at long time/div settings, widening SCOPE to 14 HP is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMqb76wkSpNtRu7Uizw6oA