### PR TITLE
feat(theme): add persisted theme tokens

### DIFF
--- a/specs/theming.md
+++ b/specs/theming.md
@@ -1,0 +1,12 @@
+# Theming readiness
+
+## Done
+
+- Semantic renderer tokens remain in `style.css`; dark and light overrides use `html[data-theme]`.
+- Theme choice persists in `localStorage` and emits `themechange` for canvas or future UI consumers.
+- Runtime geometry and data colors stay inline CSS variables.
+
+## Tailwind path
+
+- Map semantic CSS variables to Tailwind colors when Tailwind is introduced.
+- Keep rack/native-control/canvas state CSS outside utility conversion.

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; worker-src blob: 'self' http://localhost:*; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'none';">
   <title>SYNTH</title>
+  <script src="/theme-init.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -45,6 +46,11 @@
       <button id="add-midi-track-btn" disabled>+ MIDI</button>
       <button id="bounce-btn" disabled>BOUNCE</button>
       <span class="project-bar-sep" aria-hidden="true"></span>
+      <label class="theme-control" for="theme-select">THEME</label>
+      <select id="theme-select" aria-label="Theme">
+        <option value="dark">DARK</option>
+        <option value="light">LIGHT</option>
+      </select>
       <span id="midi-status" class="midi-status" aria-live="polite" aria-atomic="true">MIDI OFF</span>
       <button id="midi-enable-btn" class="midi-btn">ENABLE MIDI</button>
       <select id="midi-device-select" class="midi-select" aria-label="MIDI input device" style="display:none">

--- a/src/renderer/js/app.js
+++ b/src/renderer/js/app.js
@@ -21,6 +21,7 @@ import { PianoRoll } from './components/piano-roll.js'
 import { Tr909View } from './components/tr909-view.js'
 import { RackView } from './components/rack-view.js'
 import ShortcutManager from './shortcuts.js'
+import { applyTheme, savedTheme } from './theme.js'
 
 // ─── Per-type directory memory ────────────────────────────────────────────────
 const DIR_KEY_PROJECT = 'synth_lastProjectDir'
@@ -524,6 +525,12 @@ function setProjectOpen(name) {
 }
 
 function initProjectBar() {
+  const themeSelect = document.getElementById('theme-select')
+  if (themeSelect) {
+    themeSelect.value = savedTheme()
+    themeSelect.addEventListener('change', () => applyTheme(themeSelect.value))
+  }
+
   document.getElementById('new-project-btn')?.addEventListener('click', async () => {
     await ensureAudio()
     const handle = await FileAdapter.createProjectFolder(getLastDir(DIR_KEY_PROJECT))
@@ -969,6 +976,7 @@ function initUndoRedo() { /* migrated to initShortcuts */ }
 
 // ─── Bootstrap ─────────────────────────────────────────────────────────────
 function boot() {
+  applyTheme(savedTheme())
   Keyboard.render('keyboard')
   renderDrumPads()
   Sequencer.init('seq-tracks')

--- a/src/renderer/js/theme.js
+++ b/src/renderer/js/theme.js
@@ -1,0 +1,14 @@
+export const THEME_KEY = 'synth_theme'
+export const THEMES = new Set(['dark', 'light'])
+
+export function applyTheme(theme, root = document.documentElement) {
+  const next = THEMES.has(theme) ? theme : 'dark'
+  root.dataset.theme = next
+  localStorage.setItem(THEME_KEY, next)
+  window.dispatchEvent(new CustomEvent('themechange', { detail: { theme: next } }))
+  return next
+}
+
+export function savedTheme() {
+  return THEMES.has(localStorage.getItem(THEME_KEY)) ? localStorage.getItem(THEME_KEY) : 'dark'
+}

--- a/src/renderer/public/theme-init.js
+++ b/src/renderer/public/theme-init.js
@@ -1,0 +1,5 @@
+// Must run before style.css so a saved light theme never flashes dark.
+try {
+  const theme = localStorage.getItem('synth_theme')
+  document.documentElement.dataset.theme = theme === 'light' ? 'light' : 'dark'
+} catch {}

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -2,10 +2,9 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  /* Native widgets (select popups, scrollbars, checkboxes) follow the dark palette
-     instead of rendering light with a bright system-blue highlight. */
+  /* Native widgets follow the active theme. */
   color-scheme: dark;
-  accent-color: #00e5ff;
+  accent-color: var(--accent);
 
   --bg:        #0d0d0d;
   --bg2:       #141414;
@@ -22,7 +21,61 @@
   --black-key: #111;
   --key-active: #00e5ff;
   --glow:      0 0 8px #00e5ff, 0 0 16px #00e5ff44;
+  --surface-canvas: #080808;
+  --surface-panel: #30343a;
+  --surface-control: #1b1e22;
+  --surface-inset: #0d1114;
+  --border-strong: #59616c;
+  --border-subtle: #3d444c;
+  --text-rack-label: #b9c4d0;
+  --text-rack-muted: #97a3b0;
+  --text-inverse: #050505;
+  --rack-rail: #191919;
+  --rack-util: #1d1d1d;
+  --rack-knob: #4c545e;
+  --danger: #ff4444;
+  --danger-subtle: #ff44441a;
+  --danger-on: #000;
+  --tr909-accent: #f05a28;
+  --signal-audio: #00e5ff;
+  --signal-cv: #ff00aa;
+  --signal-gate: #39ff14;
   --font-mono: 'Courier New', Courier, monospace;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --bg: #edf0f4;
+  --bg2: #ffffff;
+  --bg3: #e2e7ed;
+  --bg4: #d5dce5;
+  --border: #aab5c2;
+  --accent: #006f9e;
+  --accent2: #b00067;
+  --accent3: #167a08;
+  --text: #17212b;
+  --text-dim: #53616f;
+  --text-bright: #081018;
+  --white-key: #ffffff;
+  --black-key: #202932;
+  --key-active: #00a6db;
+  --glow: 0 0 8px #00a6db88;
+  --surface-canvas: #c7d0da;
+  --surface-panel: #d9e0e8;
+  --surface-control: #eef2f6;
+  --surface-inset: #c2ccd7;
+  --border-strong: #748394;
+  --border-subtle: #9ba8b6;
+  --text-rack-label: #283746;
+  --text-rack-muted: #405161;
+  --text-inverse: #ffffff;
+  --rack-rail: #b6c0cb;
+  --rack-util: #cbd4dd;
+  --rack-knob: #8795a4;
+  --danger: #c62d2d;
+  --danger-subtle: #c62d2d1a;
+  --danger-on: #fff;
+  --tr909-accent: #bd4a1f;
 }
 
 html, body {
@@ -110,8 +163,8 @@ html, body {
   --rack-zoom: 1; --rack-util-h: 110px;
   position: relative; transform-origin: top left; transform: scale(var(--rack-zoom));
   background-image:
-    linear-gradient(to bottom, #1d1d1d 0 106px, #080808 106px var(--rack-util-h)),
-    repeating-linear-gradient(to bottom, #191919 0 216px, #080808 216px 220px);
+    linear-gradient(to bottom, var(--rack-util) 0 106px, var(--surface-canvas) 106px var(--rack-util-h)),
+    repeating-linear-gradient(to bottom, var(--rack-rail) 0 216px, var(--surface-canvas) 216px 220px);
   background-repeat: no-repeat, repeat;
   background-position: 0 0, 0 var(--rack-util-h);
   background-size: 100% var(--rack-util-h), 100% 100%;
@@ -124,8 +177,8 @@ html, body {
 .rack-panel {
   position: absolute; z-index: 3; box-sizing: border-box; height: 216px;
   display: flex; flex-direction: column; gap: 3px;
-  padding: 6px; color: var(--text); background: #30343a;
-  border: 1px solid #59616c; border-radius: 2px; user-select: none;
+  padding: 6px; color: var(--text); background: var(--surface-panel);
+  border: 1px solid var(--border-strong); border-radius: 2px; user-select: none;
   background-image: linear-gradient(#ffffff0d, #0000001a);
 }
 .rack-panel.selected { border-color: var(--accent); box-shadow: var(--glow); }
@@ -135,7 +188,7 @@ html, body {
    line below. Same DOM as any other panel; only the flow differs. */
 .rack-panel.docked {
   height: 232px; flex-flow: row wrap; align-content: flex-start; gap: 0;
-  border-top: 2px solid #59616c; background-image: linear-gradient(#ffffff14, #00000026); cursor: default;
+  border-top: 2px solid var(--border-strong); background-image: linear-gradient(#ffffff14, #00000026); cursor: default;
 }
 /* KEYS needs no nameplate — a piano keyboard is self-evident, and the row is
    worth more as key height. */
@@ -200,12 +253,12 @@ html, body {
 
 /* Rotary knob: a dial the pointer drags, wrapped around a hidden range input. */
 .rack-panel .knob { display: flex; flex-direction: column; align-items: center; gap: 3px; width: 40px; margin: 0; }
-.knob-cap { font-size: 8px; letter-spacing: .4px; color: #b9c4d0; white-space: nowrap; }
+.knob-cap { font-size: 8px; letter-spacing: .4px; color: var(--text-rack-label); white-space: nowrap; }
 .knob-dial {
   --angle: 0deg;
   position: relative; width: 30px; height: 30px; border-radius: 50%; cursor: ns-resize;
-  background: radial-gradient(circle at 50% 35%, #4c545e, #23272c 70%);
-  border: 1px solid #6d7681; box-shadow: 0 1px 2px #0006;
+  background: radial-gradient(circle at 50% 35%, var(--rack-knob), var(--surface-control) 70%);
+  border: 1px solid var(--border-strong); box-shadow: 0 1px 2px #0006;
 }
 .knob-dial::after {
   content: ''; position: absolute; left: 50%; top: 3px; width: 2px; height: 11px; margin-left: -1px;
@@ -229,13 +282,13 @@ html, body {
 }
 /* Controls take the slack; jack blocks stay pinned to the bottom of the panel. */
 .rack-params { flex: 1 1 auto; min-height: 0; overflow: auto; }
-.rack-panel label { display: block; font-size: 8px; line-height: 1.1; letter-spacing: .4px; margin: 0 0 4px; color: #b9c4d0; }
+.rack-panel label { display: block; font-size: 8px; line-height: 1.1; letter-spacing: .4px; margin: 0 0 4px; color: var(--text-rack-label); }
 #rack-view .rack-panel input[type=range] { height: 3px; margin: 1px 0 0; }
 #rack-view .rack-panel input[type=range]::-webkit-slider-thumb { width: 9px; height: 9px; }
-#rack-view .rack-panel select { font-size: 9px; padding: 0 2px; height: 15px; background: #1b1e22; color: var(--text-bright); border: 1px solid #59616c; }
+#rack-view .rack-panel select { font-size: 9px; padding: 0 2px; height: 15px; background: var(--surface-control); color: var(--text-bright); border: 1px solid var(--border-strong); }
 /* The popup list is browser-drawn; option colours are honoured, the highlighted
    row is not stylable without replacing <select> outright. */
-#rack-view .rack-panel option { background: #1b1e22; color: var(--text-bright); font-size: 11px; }
+#rack-view .rack-panel option { background: var(--surface-control); color: var(--text-bright); font-size: 11px; }
 #rack-view .rack-panel input[type=checkbox] { width: 12px; height: 12px; }
 
 .rack-jacks { flex: 0 0 auto; display: flex; flex-wrap: wrap; gap: 4px 5px; padding-top: 4px; }
@@ -403,9 +456,9 @@ html, body {
   box-shadow: inset 0 0 0 1px #0008;
 }
 /* Colour = signal kind; filled centre = output, hollow = input. */
-.rack-jack.audio { border-color: #00e5ff; }
-.rack-jack.cv    { border-color: #ff00aa; }
-.rack-jack.gate  { border-color: #39ff14; }
+.rack-jack.audio { border-color: var(--signal-audio); }
+.rack-jack.cv    { border-color: var(--signal-cv); }
+.rack-jack.gate  { border-color: var(--signal-gate); }
 .rack-jack.out.audio { background: #00e5ff40; }
 .rack-jack.out.cv    { background: #ff00aa40; }
 .rack-jack.out.gate  { background: #39ff1440; }
@@ -423,8 +476,8 @@ html, body {
 
 .rec-btn {
   background: var(--bg4);
-  border: 1px solid #ff4444;
-  color: #ff4444;
+  border: 1px solid var(--danger);
+  color: var(--danger);
   font-family: var(--font-mono);
   font-size: 11px;
   padding: 4px 14px;
@@ -432,8 +485,8 @@ html, body {
   letter-spacing: 1px;
   transition: all 0.1s;
 }
-.rec-btn:hover { background: #ff44441a; }
-.rec-btn.recording { background: #ff4444; color: #000; }
+.rec-btn:hover { background: var(--danger-subtle); }
+.rec-btn.recording { background: var(--danger); color: var(--danger-on); }
 
 .rec-timer {
   font-size: 13px;
@@ -444,7 +497,7 @@ html, body {
 
 .rec-status {
   font-size: 11px;
-  color: #ff4444;
+  color: var(--danger);
   letter-spacing: 1px;
 }
 
@@ -1397,6 +1450,19 @@ button { font-family: var(--font-mono); }
   opacity: 0.35;
   cursor: default;
 }
+.theme-control {
+  color: var(--text-dim);
+  font-size: 9px;
+  letter-spacing: 1px;
+}
+#theme-select {
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font: inherit;
+  font-size: 10px;
+  padding: 3px;
+}
 #project-name {
   color: var(--accent);
   font-size: 11px;
@@ -1610,7 +1676,7 @@ input[type=range].mixer-pan {
   color: var(--text-dim);
   cursor: pointer;
 }
-.mixer-strip .mute-btn.active { border-color: #ff4444; color: #ff4444; }
+.mixer-strip .mute-btn.active { border-color: var(--danger); color: var(--danger); }
 .mixer-strip .solo-btn.active { border-color: var(--accent); color: var(--accent); }
 
 /* ─── Phase 3: MIDI Controls ─────────────────────────────────────────────── */

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyTheme, savedTheme } from '../src/renderer/js/theme.js'
+
+describe('theme', () => {
+  it('applies and persists valid themes', () => {
+    const root = document.documentElement
+    const changed = vi.fn()
+    window.addEventListener('themechange', changed, { once: true })
+
+    expect(applyTheme('light')).toBe('light')
+    expect(root.dataset.theme).toBe('light')
+    expect(savedTheme()).toBe('light')
+    expect(changed).toHaveBeenCalledWith(expect.objectContaining({ detail: { theme: 'light' } }))
+  })
+
+  it('falls back to dark for unknown themes', () => {
+    expect(applyTheme('neon')).toBe('dark')
+    expect(savedTheme()).toBe('dark')
+  })
+
+  it('restores a saved light theme', () => {
+    localStorage.setItem('synth_theme', 'light')
+    expect(savedTheme()).toBe('light')
+    expect(applyTheme(savedTheme())).toBe('light')
+    expect(document.documentElement.dataset.theme).toBe('light')
+  })
+})


### PR DESCRIPTION
Adds persisted Dark/Light themes, semantic renderer tokens, pre-paint theme bootstrap, and saved-theme coverage.\n\nChecks: npm test; npm run build.