### PR TITLE
feat(theme): add rainbow theme

### DIFF
--- a/specs/theming.md
+++ b/specs/theming.md
@@ -2,7 +2,7 @@
 
 ## Done
 
-- Semantic renderer tokens remain in `style.css`; dark and light overrides use `html[data-theme]`.
+- Semantic renderer tokens remain in `style.css`; dark, light, and rainbow overrides use `html[data-theme]`.
 - Theme choice persists in `localStorage` and emits `themechange` for canvas or future UI consumers.
 - Runtime geometry and data colors stay inline CSS variables.
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -50,6 +50,7 @@
       <select id="theme-select" aria-label="Theme">
         <option value="dark">DARK</option>
         <option value="light">LIGHT</option>
+        <option value="rainbow">RAINBOW</option>
       </select>
       <span id="midi-status" class="midi-status" aria-live="polite" aria-atomic="true">MIDI OFF</span>
       <button id="midi-enable-btn" class="midi-btn">ENABLE MIDI</button>

--- a/src/renderer/js/theme.js
+++ b/src/renderer/js/theme.js
@@ -1,5 +1,5 @@
 export const THEME_KEY = 'synth_theme'
-export const THEMES = new Set(['dark', 'light'])
+export const THEMES = new Set(['dark', 'light', 'rainbow'])
 
 export function applyTheme(theme, root = document.documentElement) {
   const next = THEMES.has(theme) ? theme : 'dark'

--- a/src/renderer/public/theme-init.js
+++ b/src/renderer/public/theme-init.js
@@ -1,5 +1,5 @@
-// Must run before style.css so a saved light theme never flashes dark.
+// Must run before style.css so a saved theme never flashes dark.
 try {
   const theme = localStorage.getItem('synth_theme')
-  document.documentElement.dataset.theme = theme === 'light' ? 'light' : 'dark'
+  document.documentElement.dataset.theme = ['light', 'rainbow'].includes(theme) ? theme : 'dark'
 } catch {}

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -78,6 +78,43 @@
   --tr909-accent: #bd4a1f;
 }
 
+:root[data-theme="rainbow"] {
+  --bg: #160b2e;
+  --bg2: #211044;
+  --bg3: #30165d;
+  --bg4: #412075;
+  --border: #6c3da1;
+  --accent: #00e5ff;
+  --accent2: #ff43d0;
+  --accent3: #b8ff36;
+  --text: #efe8ff;
+  --text-dim: #b69bd7;
+  --text-bright: #ffffff;
+  --white-key: #fbf7ff;
+  --black-key: #1d0a3a;
+  --key-active: #ffdd33;
+  --glow: 0 0 8px #00e5ff, 0 0 16px #ff43d088;
+  --surface-canvas: #10051f;
+  --surface-panel: #3b1a68;
+  --surface-control: #27104d;
+  --surface-inset: #19082f;
+  --border-strong: #af7ee8;
+  --border-subtle: #8152bb;
+  --text-rack-label: #f0dbff;
+  --text-rack-muted: #d0b5ee;
+  --text-inverse: #160b2e;
+  --rack-rail: #240e48;
+  --rack-util: #32145f;
+  --rack-knob: #a05bdd;
+  --danger: #ff5a70;
+  --danger-subtle: #ff5a701a;
+  --danger-on: #1a0610;
+  --tr909-accent: #ff9d3d;
+  --signal-audio: #00e5ff;
+  --signal-cv: #ff43d0;
+  --signal-gate: #b8ff36;
+}
+
 html, body {
   height: 100%;
   background: var(--bg);

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -24,4 +24,11 @@ describe('theme', () => {
     expect(applyTheme(savedTheme())).toBe('light')
     expect(document.documentElement.dataset.theme).toBe('light')
   })
+
+  it('applies and restores the rainbow theme', () => {
+    localStorage.setItem('synth_theme', 'rainbow')
+    expect(savedTheme()).toBe('rainbow')
+    expect(applyTheme(savedTheme())).toBe('rainbow')
+    expect(document.documentElement.dataset.theme).toBe('rainbow')
+  })
 })


### PR DESCRIPTION
Adds Rainbow to the existing theme picker, persists and restores it before first paint, and covers it with a persistence test. Validation: npm test -- --run tests/theme.test.js.