### PR TITLE
feat(midi): MIDI bridge phases 1-3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,17 @@ rack/modules/*.js       one definition per module: ports, params, create(ctx, op
 utils/cv.js             PURE 1 V/oct math — 0.1 CV = 1 octave, 0.0 = C4
 ```
 
+External MIDI integration is specced in `specs/midi-bridge.md`. Phases 1–3 are
+in: `midi/midi-message.js` parses raw bytes into typed events (channel nibble
+kept, 0-indexed), `midi/midi-routing.js` maps a channel to the tracks that
+claim it, `midi/live-instrument.js` plays a track live (palette voices, or a
+lazily mounted rack driven through its `midi-in` module). `MidiController`
+dispatches one `midi-event` on `document`; `app.js` routes it. Clock in
+(phase 4) and MIDI out (phase 5) are not started — build them only when
+something on the other end needs them.
+
+Web MIDI is secure-context only, so none of it works on the LAN http route.
+
 Phase 4 integration:
 
 - MIDI tracks use `instrument: { type: 'palette', paletteKey }` or

--- a/specs/midi-bridge.md
+++ b/specs/midi-bridge.md
@@ -1,0 +1,222 @@
+# MIDI Bridge — external sequencer integration
+
+Make the app a real MIDI citizen so an external node/step sequencer (Midinous, hardware, any DAW via a loopback port) can drive it: per-channel routing to different instruments, CC/bend into racks, live playing of rack instruments, optional clock sync, optional MIDI out.
+
+Motivating case: [Midinous](https://midinous.com) creates two virtual ports at startup — **Midinous Port** (16 channels of note + CC) and **Midinous Clock Port** (clock + start/stop). Everything valuable about it is per-channel and CC-shaped, which is exactly what this app currently throws away.
+
+---
+
+## Status
+
+| Phase | State | Commit |
+|---|---|---|
+| 1 — Pure message parser | done | `3665564` |
+| 2 — Channel routing + live instruments | done | `c9ddf05` |
+| 3 — CC + pitch bend into racks | done | `76214f1` |
+| 4 — Clock in (optional) | not started | |
+| 5 — MIDI out (optional) | not started | |
+
+Phases 1–3 are the bridge. Phases 4–5 are opt-in; do not build them speculatively — build 4 when transport drift actually bites, build 5 when there is real gear or software on the other end.
+
+---
+
+## Ground rules
+
+- Parsing, routing and clock estimation are **pure functions in their own modules with unit tests**. `MidiController` stays the imperative shell that owns the Web MIDI handles and dispatches DOM events. Same functional-core split the rack already uses.
+- No new dependency. Web MIDI + existing `RackEngine` cover all of this.
+- `npm test` green before each commit. Conventional commits (`feat:`, `fix:`, `refactor:`).
+- Each phase ends committable and does not break the existing MIDI record path.
+
+### Deployment constraint (read before testing)
+
+Web MIDI is `[SecureContext]`. `navigator.requestMIDIAccess` is **undefined** on `http://themachine/synth/`, so this whole feature is dead on the LAN route by design — same class of limitation as the AudioWorklet recorder. Test on:
+
+| Target | Web MIDI |
+|---|---|
+| Electron (`npm run dev`, and packaged `file://`) | works — both secure contexts, `src/main/index.js` registers no `setPermissionRequestHandler` so Electron default-grants |
+| `https://synth.zakharhome.org` | works in Chrome/Edge; Firefox prompts; Safari has no Web MIDI |
+| `http://themachine/synth/` | never — leave the existing "not supported" message |
+
+Nothing in phases 1–5 may end up on the critical path of core audio.
+
+---
+
+## Current state — where the gaps are
+
+| Fact | Where |
+|---|---|
+| Channel nibble discarded — `status & 0xf0` only | `src/renderer/js/midi/MidiController.js:107` |
+| Only `0x80`/`0x90` handled. No CC, bend, clock | `MidiController.js:112-136` |
+| Live MIDI goes straight to `currentPalette.createVoice`, one mono-timbral destination, racks unreachable | `src/renderer/js/app.js:829-847` |
+| Rack instruments only playable from the timeline | `src/renderer/js/playback/timeline-player.js:21-36` (`rackInstrument`, `instrumentFor`) |
+| `midi-in` module already exposes `mod` and `pb` outputs and already accepts `{type:'mod'}` / `{type:'pitch-bend'}` events — nothing ever sends them | `src/renderer/js/rack/modules/midi-in.js:34-35`, `:90-93` |
+| No MIDI out anywhere — `access.outputs` untouched | — |
+| Project schema is at **version 4**, `migrate()` at `store/ProjectStore.js:38` (note: CLAUDE.md still says version 2 — it is stale) | `store/ProjectStore.js:18,38-70` |
+| MIDI toolbar markup: enable button, status, device select, rec button | `src/renderer/index.html:55-60` |
+| Existing tests to extend, not replace | `tests/midi-controller.test.js`, `tests/rack-midi.test.js`, `tests/store-midi.test.js` |
+
+Web MIDI always delivers complete messages, so **running status does not need handling**.
+
+---
+
+## Phase 1 — Pure message parser
+
+**New:** `src/renderer/js/midi/midi-message.js`
+
+```js
+export function parseMidiMessage(bytes) // Uint8Array|number[] -> event | null
+```
+
+Returns exactly one of, or `null` for anything unhandled (sysex, aftertouch, program change):
+
+| Return | From |
+|---|---|
+| `{ kind:'note-on', channel, pitch, velocity }` | `0x90`, velocity > 0. `velocity` stays 0–127 raw |
+| `{ kind:'note-off', channel, pitch }` | `0x80`, **or** `0x90` with velocity 0 |
+| `{ kind:'cc', channel, controller, value }` | `0xB0`, `value` 0–127 raw |
+| `{ kind:'pitch-bend', channel, value }` | `0xE0`, 14-bit `(msb<<7)\|lsb` normalised to **-1..1**, centre 8192 → exactly `0` |
+| `{ kind:'clock' }` / `'start'` / `'stop'` / `'continue'` | `0xF8` / `0xFA` / `0xFC` / `0xFB` |
+
+`channel` is `status & 0x0f`, **0-indexed** (Midinous channel 1 = `channel: 0`). Document that once at the top of the file and never re-index anywhere else.
+
+**Change:** `MidiController.js:105` `_onMidiMessage` delegates to `parseMidiMessage` and dispatches a single `midi-event` CustomEvent carrying the parsed object plus `time: e.timeStamp`. Keep dispatching the existing `midi-note-on` / `midi-note-off` events unchanged so nothing downstream breaks in this phase; recording (`MidiController.js:66-97`) keeps working off the parsed note events and stays channel-agnostic.
+
+**Test:** `tests/midi-message.test.js` — one `describe` per kind. Must cover: note-on with velocity 0 is a note-off; bend centre is 0 and extremes are ±1; unknown status returns `null`; channel nibble survives on all channel messages.
+
+---
+
+## Phase 2 — Channel routing + live instruments
+
+The payload phase. Sixteen Midinous channels must be able to hit sixteen different instruments, and rack instruments must be playable live.
+
+### 2a. Routing (pure)
+
+**New:** `src/renderer/js/midi/midi-routing.js`
+
+```js
+export function routeChannel(tracks, channel, armedTrackId) // -> trackId[]
+```
+
+Rules, in order:
+
+1. Tracks with `track.midiChannel === channel` win. Return **all** of them — layering two instruments on one channel is free and someone will want it.
+2. If no track anywhere declares a `midiChannel`, fall back to `[armedTrackId]` (omni behaviour — preserves today's "plug in a keyboard and it just plays").
+3. Otherwise return `[]`. Silence is correct: the user has declared a routing map and this channel is not in it.
+
+`track.midiChannel` is a new **optional** field, `0`–`15` or absent. Absent is the default, so **no schema bump and no `migrate()` step** — read it as `track.midiChannel ?? null`.
+
+**Test:** `tests/midi-routing.test.js` — each of the three rules, plus two tracks on one channel returning both.
+
+### 2b. Live instruments (shell)
+
+**New:** `src/renderer/js/midi/live-instrument.js`
+
+```js
+export function liveInstrumentFor(track, { palettes, ctx, output, racks, mountRack })
+// -> { noteOn(pitch, velocity), noteOff(pitch), send(event), dispose() } | null
+```
+
+- **Palette track** — `palette.createVoice(ctx, output, freq, velocity/127, ctx.currentTime)`, keep a `pitch → voice` map, `noteOff` calls `voice.stop(ctx.currentTime)`. Same maths as `app.js:833-838`; move it here rather than duplicating it.
+- **Rack track** — mount the rack, find the `midi-in` module the way `timeline-player.js:33` does:
+  `[...handle.mods].find(([, entry]) => entry.def?.type === 'midi-in')?.[0]`
+  then `RackEngine.sendEvent(handle, moduleId, 'note', { type:'note-on', note: pitch, velocity, time: ctx.currentTime })` and the matching `note-off`. Note the argument name is `note`, not `pitch` — `midi-in.js:66` reads `event.note ?? event.pitch`.
+- `send(event)` forwards `{type:'mod'|'pitch-bend'}` straight through to the same module (phase 3 uses it; wire the pass-through now, it is two lines).
+- Copy the mount options from `timeline-player.js:64-71` (`output`, `getBuffer`, `onParam`).
+
+**Live mounts are separate from `TimelinePlayer._instrumentRackHandles`.** During playback the same rack ends up mounted twice — timeline notes on one, live notes on the other. Audio is correct, CPU is doubled. Mark it:
+
+```js
+// ponytail: live rack mount is independent of TimelinePlayer's, so a rack
+// played live during transport is mounted twice. Share handles if CPU bites.
+```
+
+Lifecycle: mount lazily on first note for that track, dispose when the track's `instrument` changes or the track is removed.
+
+### 2c. Wiring
+
+Replace the `midi-note-on` / `midi-note-off` listeners at `app.js:829-847` with one `midi-event` listener that calls `routeChannel(...)` and dispatches to each returned track's live instrument. Armed track is already tracked as `_midiTargetTrackId` (`app.js:768`, kept in sync by the `track-selected` handler at `app.js:856`).
+
+UI: a channel selector per MIDI track — smallest thing that works is a `<select>` (Omni + 1–16) in the track header next to the existing instrument control. Writing it dispatches a `SetTrackMidiChannel(trackId, channel)` command in `ProjectStore` alongside the other track commands near `store/ProjectStore.js:74`.
+
+**Test:** extend `tests/store-midi.test.js` for the new command; the live-instrument shell needs no test beyond the routing and parser units — the pure parts carry the logic.
+
+---
+
+## Phase 3 — CC + pitch bend into racks
+
+Small once phase 2 lands: in the `midi-event` handler, map `kind:'cc'` with `controller === 1` (mod wheel) to `send({ type:'mod', value: value/127 })` and `kind:'pitch-bend'` to `send({ type:'pitch-bend', value })`. `midi-in.js:91-92` already consumes both, and `pb` is already scaled by the module's `bendRange` param — do not scale it twice at the call site.
+
+Other CC numbers: ignore for now. Generic `CC → rack param` mapping is a bigger feature and belongs with a learn-mode UI.
+
+```js
+// ponytail: only CC1 mapped. Add a CC-learn map when a second controller matters.
+```
+
+**Test:** extend `tests/rack-midi.test.js` — assert a `mod` event moves the `mod` ConstantSource offset and that bend of `1` lands at `bendRange/24`.
+
+---
+
+## Phase 4 — Clock in (optional, build only if drift bites)
+
+**New pure module:** `src/renderer/js/midi/midi-clock.js`
+
+```js
+export function estimateBpm(tickTimes)  // last N clock timestamps (ms) -> bpm | null
+```
+
+24 pulses per quarter note: `bpm = 60000 / (meanInterval * 24)`. Use a rolling window (8–24 ticks), return `null` until the window is full, and median-filter the intervals — one jittery tick must not yank the tempo.
+
+Shell: `start`/`continue` starts `TimelinePlayer` from the current beat, `stop` stops it, `clock` feeds `estimateBpm` and updates BPM when the estimate moves more than ~0.5 BPM. External sync must be **opt-in via a toggle**, defaulting off — an app that silently follows a foreign clock is a support ticket.
+
+**Test:** `tests/midi-clock.test.js` — steady 120 BPM tick stream returns 120±0.1; one outlier tick does not move the estimate.
+
+---
+
+## Phase 5 — MIDI out (optional)
+
+`MidiController` gains `getOutputs()`, `selectOutput(id)`, and `send(bytes, timestamp)` mirroring the input side (`MidiController.js:43-62`). A track's `instrument` gains `{ type: 'midi-out', portId, channel }`, handled in `instrumentFor` (`timeline-player.js:28`) so timeline playback emits note-on/off to hardware. Use the `timestamp` argument of `MIDIOutput.send` for scheduling — do **not** `setTimeout` note-offs.
+
+Do not build this until something is actually listening on the other end.
+
+---
+
+## Verify
+
+```sh
+npm test          # unit suite, all phases
+npm run dev       # Electron — the only local secure context
+```
+
+Manual acceptance (phase 2 done):
+
+1. Start Midinous. Confirm **Midinous Port** appears in the app's device select.
+2. Two MIDI tracks: one palette on channel 1, one rack instrument on channel 2.
+3. Points in Midinous on channels 1 and 2 play the two different instruments simultaneously.
+4. Mod wheel CC1 from Midinous moves the rack's `MOD` output (phase 3).
+
+Windows note: Midinous claims it auto-creates its ports; Windows has no native virtual MIDI, so it must ship its own driver. If the ports do not appear, install [loopMIDI](https://www.tobias-erichsen.de/software/loopmidi.html) and point Midinous at a loopback port. Verify with the itch.io demo before buying.
+
+---
+
+## Explicitly out of scope
+
+| Item | Why | Revisit when |
+|---|---|---|
+| Node/path grid sequencer inside the app (Midinous clone) | Weeks of canvas UI. Buy the $25 tool first | The bridge proves the workflow sticks — then the cheap 20% is a `NOUS` rack module emitting into the existing event domain, reusing `RackEngine.sendEvent`, clock and poly |
+| MPE | No hardware, no demand | Ever asked for |
+| Sysex | `requestMIDIAccess({ sysex: false })` stays | Never, ideally |
+| Generic CC-learn mapping to rack params | Needs a learn-mode UI to be usable | A second controller shows up |
+| MIDI on the LAN route | Not a secure context. Not fixable in app code | Never |
+
+---
+
+## Suggested agent split for a fresh session
+
+| Step | Agent | Scope |
+|---|---|---|
+| Phase 1 | `cavecrew-builder` | 2 files (`midi-message.js`, `MidiController.js`) + 1 test file |
+| Phase 2 | `cavecrew-implementer` | Multi-file: routing, live-instrument, `app.js` wiring, store command, track-header UI. Brief must carry the `file:line` table above |
+| Phase 3 | `cavecrew-builder` | 1 file + test extension |
+| Review | `cavecrew-reviewer` | Diff per phase, before commit |
+
+Main thread orchestrates and commits. Do not let an agent read `app.js` whole — point it at line ranges.

--- a/src/renderer/js/app.js
+++ b/src/renderer/js/app.js
@@ -9,6 +9,9 @@ import Keyboard from './keyboard.js'
 import Sequencer from './sequencer.js'
 import Recorder from './recorder.js'
 import ProjectStore, { AddTrack, AddClip, SetMixerParam, SetBpm, RemoveTrack } from './store/ProjectStore.js'
+import RackEngine from './rack/rack-engine.js'
+import { routeChannel } from './midi/midi-routing.js'
+import { liveInstrumentFor } from './midi/live-instrument.js'
 import FileAdapter from './io/FileAdapter.js'
 import { pickAudioFile } from './io/audio-picker.js'
 import AudioStore from './audio-store.js'
@@ -32,6 +35,15 @@ function setLastDir(key, path) { if (path) localStorage.setItem(key, path) }
 let currentPaletteKey = 'classic'
 let currentPalette = Palettes.classic
 const activeVoices = {} // midi note → voice object
+const _liveInstruments = new Map() // trackId → { sig, inst }
+
+/** Tear down every live MIDI instrument — the old project's tracks are gone. */
+function disposeLiveInstruments() {
+  for (const entry of _liveInstruments.values()) {
+    try { entry.inst.dispose() } catch (err) {}
+  }
+  _liveInstruments.clear()
+}
 
 let _arrangementView = null
 let _pianoRoll = null
@@ -536,6 +548,7 @@ function initProjectBar() {
     const handle = await FileAdapter.createProjectFolder(getLastDir(DIR_KEY_PROJECT))
     if (handle) setLastDir(DIR_KEY_PROJECT, typeof handle === 'string' ? handle : null)
     if (!handle) return
+    disposeLiveInstruments()
     ProjectStore.reset()
     AudioStore.reset()
     AudioStore.setProjectDir(handle)
@@ -561,6 +574,7 @@ function initProjectBar() {
       alert(`Could not open project:\n${e.message}`)
       return
     }
+    disposeLiveInstruments()
     ProjectStore.load(state)
     AudioStore.reset()
     AudioStore.setProjectDir(handle)
@@ -825,25 +839,83 @@ function initMidi() {
     switchMode('arrange')
   })
 
-  // Route live MIDI note events → synth voices (same as keyboard)
-  document.addEventListener('midi-note-on', (e) => {
+  // Route live MIDI note events → track instruments (routeChannel), falling
+  // back to the plain keyboard behaviour when no MIDI tracks exist at all.
+  document.addEventListener('midi-event', (e) => {
+    const detail = e.detail
+    if (detail.kind !== 'note-on' && detail.kind !== 'note-off') return
     ensureAudio()
     const ctx = AudioEngine.getContext()
     if (!ctx) return
-    const note = e.detail.pitch
-    if (activeVoices[note]) return
-    const freq = 440 * Math.pow(2, (note - 69) / 12)
-    try {
-      const voice = currentPalette.createVoice(ctx, AudioEngine.getMasterInput(), freq, e.detail.velocity / 127, ctx.currentTime)
-      activeVoices[note] = voice
-    } catch (err) {}
-  })
-  document.addEventListener('midi-note-off', (e) => {
-    const note = e.detail.pitch
-    if (activeVoices[note]) {
-      const ctx = AudioEngine.getContext()
-      try { activeVoices[note].stop(ctx ? ctx.currentTime : 0) } catch (err) {}
-      delete activeVoices[note]
+
+    const state = ProjectStore.getState()
+    const midiTracks = state.tracks.filter(t => t.type === 'midi')
+
+    // Prune instruments for tracks that no longer exist.
+    for (const [trackId, entry] of [..._liveInstruments]) {
+      if (!state.tracks.some(t => t.id === trackId)) {
+        entry.inst.dispose()
+        _liveInstruments.delete(trackId)
+      }
+    }
+
+    const ids = routeChannel(midiTracks, detail.channel, _midiTargetTrackId)
+
+    if (ids.length === 0 && midiTracks.length === 0) {
+      // No MIDI tracks at all — plain keyboard behaviour.
+      const note = detail.pitch
+      if (detail.kind === 'note-on') {
+        if (activeVoices[note]) return
+        const freq = 440 * Math.pow(2, (note - 69) / 12)
+        try {
+          const voice = currentPalette.createVoice(ctx, AudioEngine.getMasterInput(), freq, detail.velocity / 127, ctx.currentTime)
+          activeVoices[note] = voice
+        } catch (err) {}
+      } else {
+        if (activeVoices[note]) {
+          try { activeVoices[note].stop(ctx.currentTime) } catch (err) {}
+          delete activeVoices[note]
+        }
+      }
+      return
+    }
+
+    for (const trackId of ids) {
+      const track = state.tracks.find(t => t.id === trackId)
+      if (!track) continue
+
+      const sig = JSON.stringify(track.instrument ?? null)
+      let entry = _liveInstruments.get(trackId)
+      if (entry && entry.sig !== sig) {
+        entry.inst.dispose()
+        entry = null
+      }
+      if (!entry) {
+        const output = MixerEngine.getOutput(track.mixerChannelId) || AudioEngine.getMasterInput()
+        const inst = liveInstrumentFor(track, {
+          palettes: Palettes,
+          ctx,
+          output,
+          racks: state.racks,
+          mountRack: rack => RackEngine.mount(ctx, rack, {
+            output,
+            getBuffer: fileKey => AudioStore.getBufferOrLoad?.(fileKey) ?? null,
+            onParam: (target, value) => {
+              const [channelId, param] = target.split('.')
+              if (param === 'volume') MixerEngine.setVolume(channelId, value)
+              else if (param === 'pan') MixerEngine.setPan(channelId, value)
+            }
+          })
+        })
+        if (!inst) continue
+        entry = { sig, inst }
+        _liveInstruments.set(trackId, entry)
+      }
+
+      try {
+        if (detail.kind === 'note-on') entry.inst.noteOn(detail.pitch, detail.velocity)
+        else entry.inst.noteOff(detail.pitch)
+      } catch (err) {}
     }
   })
 

--- a/src/renderer/js/app.js
+++ b/src/renderer/js/app.js
@@ -843,7 +843,7 @@ function initMidi() {
   // back to the plain keyboard behaviour when no MIDI tracks exist at all.
   document.addEventListener('midi-event', (e) => {
     const detail = e.detail
-    if (detail.kind !== 'note-on' && detail.kind !== 'note-off') return
+    if (detail.kind !== 'note-on' && detail.kind !== 'note-off' && detail.kind !== 'cc' && detail.kind !== 'pitch-bend') return
     ensureAudio()
     const ctx = AudioEngine.getContext()
     if (!ctx) return
@@ -862,7 +862,8 @@ function initMidi() {
     const ids = routeChannel(midiTracks, detail.channel, _midiTargetTrackId)
 
     if (ids.length === 0 && midiTracks.length === 0) {
-      // No MIDI tracks at all — plain keyboard behaviour.
+      // No MIDI tracks at all — plain keyboard behaviour, notes only.
+      if (detail.kind !== 'note-on' && detail.kind !== 'note-off') return
       const note = detail.pitch
       if (detail.kind === 'note-on') {
         if (activeVoices[note]) return
@@ -914,7 +915,12 @@ function initMidi() {
 
       try {
         if (detail.kind === 'note-on') entry.inst.noteOn(detail.pitch, detail.velocity)
-        else entry.inst.noteOff(detail.pitch)
+        else if (detail.kind === 'note-off') entry.inst.noteOff(detail.pitch)
+        // ponytail: only CC1 mapped. Add a CC-learn map when a second controller matters.
+        else if (detail.kind === 'cc') {
+          if (detail.controller === 1) entry.inst.send({ type: 'mod', value: detail.value / 127 })
+        }
+        else entry.inst.send({ type: 'pitch-bend', value: detail.value })
       } catch (err) {}
     }
   })

--- a/src/renderer/js/components/arrangement-view.js
+++ b/src/renderer/js/components/arrangement-view.js
@@ -12,7 +12,7 @@ import {
   visibleBeatRange
 } from '../utils/timeline-math.js'
 
-import ProjectStore, { MoveClip, TrimClip, RemoveTrack, DuplicateClip, RemoveClip, TileClip } from '../store/ProjectStore.js'
+import ProjectStore, { MoveClip, TrimClip, RemoveTrack, DuplicateClip, RemoveClip, TileClip, SetTrackMidiChannel } from '../store/ProjectStore.js'
 import AudioStore from '../audio-store.js'
 
 // Layout constants
@@ -499,7 +499,20 @@ export class ArrangementView {
       soloBtn.className = 'solo-btn'
       soloBtn.textContent = 'S'
 
-      div.append(name, muteBtn, soloBtn)
+      const midiChSel = document.createElement('select')
+      midiChSel.className = 'track-midi-ch'
+      const omniOpt = document.createElement('option')
+      omniOpt.value = ''
+      omniOpt.textContent = 'Omni'
+      midiChSel.appendChild(omniOpt)
+      for (let ch = 0; ch < 16; ch++) {
+        const opt = document.createElement('option')
+        opt.value = String(ch)
+        opt.textContent = String(ch + 1)
+        midiChSel.appendChild(opt)
+      }
+
+      div.append(name, muteBtn, soloBtn, midiChSel)
       this._headerList.appendChild(div)
     }
 
@@ -537,6 +550,12 @@ export class ArrangementView {
         }))
       }
 
+      const midiChSel = item.querySelector('.track-midi-ch')
+      midiChSel.style.display = track.type === 'midi' ? '' : 'none'
+      midiChSel.value = track.midiChannel ?? ''
+      midiChSel.onchange = () => this._store.dispatch(
+        SetTrackMidiChannel(track.id, midiChSel.value === '' ? null : Number(midiChSel.value))
+      )
     })
   }
 

--- a/src/renderer/js/components/arrangement-view.js
+++ b/src/renderer/js/components/arrangement-view.js
@@ -12,8 +12,9 @@ import {
   visibleBeatRange
 } from '../utils/timeline-math.js'
 
-import ProjectStore, { MoveClip, TrimClip, RemoveTrack, DuplicateClip, RemoveClip, TileClip, SetTrackMidiChannel } from '../store/ProjectStore.js'
+import ProjectStore, { MoveClip, TrimClip, RemoveTrack, DuplicateClip, RemoveClip, TileClip, SetTrackMidiChannel, SetTrackInstrument } from '../store/ProjectStore.js'
 import AudioStore from '../audio-store.js'
+import Palettes from '../palettes.js'
 
 // Layout constants
 const TRACK_HEADER_W = 160  // px — left sidebar with track names
@@ -512,7 +513,10 @@ export class ArrangementView {
         midiChSel.appendChild(opt)
       }
 
-      div.append(name, muteBtn, soloBtn, midiChSel)
+      const instrumentSel = document.createElement('select')
+      instrumentSel.className = 'track-instrument'
+
+      div.append(name, muteBtn, soloBtn, midiChSel, instrumentSel)
       this._headerList.appendChild(div)
     }
 
@@ -556,6 +560,34 @@ export class ArrangementView {
       midiChSel.onchange = () => this._store.dispatch(
         SetTrackMidiChannel(track.id, midiChSel.value === '' ? null : Number(midiChSel.value))
       )
+
+      const instrumentSel = item.querySelector('.track-instrument')
+      instrumentSel.style.display = track.type === 'midi' ? '' : 'none'
+      instrumentSel.innerHTML = ''
+      // tr909 is the 909 editor's own transport, not a playable voice — its
+      // createVoice is a silent stub (palettes.js:389), so keep it out.
+      for (const key of Object.keys(Palettes).filter(k => k !== 'tr909')) {
+        const opt = document.createElement('option')
+        opt.value = `p:${key}`
+        opt.textContent = Palettes[key].name || key
+        instrumentSel.appendChild(opt)
+      }
+      for (const rack of Object.values(state.racks || {})) {
+        const opt = document.createElement('option')
+        opt.value = `r:${rack.id}`
+        opt.textContent = rack.name || rack.id
+        instrumentSel.appendChild(opt)
+      }
+      const instrument = track.instrument
+      instrumentSel.value = instrument && instrument.type === 'rack'
+        ? `r:${instrument.rackId}`
+        : `p:${(instrument && instrument.paletteKey) || track.paletteKey || 'classic'}`
+      instrumentSel.onchange = () => {
+        const [kind, id] = instrumentSel.value.split(':')
+        this._store.dispatch(SetTrackInstrument(track.id,
+          kind === 'r' ? { type: 'rack', rackId: id } : { type: 'palette', paletteKey: id }
+        ))
+      }
     })
   }
 

--- a/src/renderer/js/midi/MidiController.js
+++ b/src/renderer/js/midi/MidiController.js
@@ -4,6 +4,7 @@
  * live note routing (fires CustomEvents on document), and
  * punch-in recording to produce MidiClip note arrays.
  */
+import { parseMidiMessage } from './midi-message.js'
 
 let _noteIdCounter = 0
 function genNoteId() { return `mn-${++_noteIdCounter}-${Date.now()}` }
@@ -103,13 +104,13 @@ const MidiController = {
   },
 
   _onMidiMessage(e) {
-    const [status, data1, data2] = e.data
-    const type     = status & 0xf0
-    const pitch    = data1
-    const velocity = data2
+    const parsed = parseMidiMessage(e.data)
+    if (!parsed) return
 
-    // Note On (velocity > 0)
-    if (type === 0x90 && velocity > 0) {
+    document.dispatchEvent(new CustomEvent('midi-event', { detail: { ...parsed, time: e.timeStamp } }))
+
+    if (parsed.kind === 'note-on') {
+      const { pitch, velocity } = parsed
       document.dispatchEvent(new CustomEvent('midi-note-on', { detail: { pitch, velocity } }))
       if (this._recording) {
         const startBeat = this._perfToBeat(performance.now())
@@ -118,8 +119,8 @@ const MidiController = {
       return
     }
 
-    // Note Off  (or Note On vel=0)
-    if (type === 0x80 || (type === 0x90 && velocity === 0)) {
+    if (parsed.kind === 'note-off') {
+      const { pitch } = parsed
       document.dispatchEvent(new CustomEvent('midi-note-off', { detail: { pitch } }))
       if (this._recording && this._pendingNotes[pitch]) {
         const p = this._pendingNotes[pitch]

--- a/src/renderer/js/midi/live-instrument.js
+++ b/src/renderer/js/midi/live-instrument.js
@@ -1,0 +1,76 @@
+// live-instrument.js — plays one track live from external MIDI. Palette
+// tracks make voices directly; rack tracks mount lazily and drive the
+// track's midi-in module. Same note maths as timeline-player.js.
+
+import RackEngine from '../rack/rack-engine.js'
+
+export function liveInstrumentFor(track, { palettes, ctx, output, racks, mountRack }) {
+  const instrument = track.instrument || { type: 'palette', paletteKey: track.paletteKey || 'classic' }
+
+  if (instrument.type === 'rack') {
+    const rack = racks[instrument.rackId]
+    if (!rack) return null
+
+    let handle = null
+    let moduleId = null
+    let unusable = false          // rack has no midi-in — do not remount every note
+    const held = new Set()        // pitches currently gated, so a repeat note-on
+                                  // cannot orphan a voice in midi-in's allocator
+    const ensureMounted = () => {
+      if (handle || unusable) return
+      // ponytail: live rack mount is independent of TimelinePlayer's, so a rack
+      // played live during transport is mounted twice. Share handles if CPU bites.
+      handle = mountRack(rack)
+      moduleId = [...handle.mods].find(([, entry]) => entry.def?.type === 'midi-in')?.[0]
+      if (!moduleId) { RackEngine.unmount(handle); handle = null; unusable = true }
+    }
+
+    return {
+      noteOn(pitch, velocity) {
+        if (held.has(pitch)) return
+        ensureMounted()
+        if (!moduleId) return
+        held.add(pitch)
+        RackEngine.sendEvent(handle, moduleId, 'note', { type: 'note-on', note: pitch, velocity, time: ctx.currentTime })
+      },
+      noteOff(pitch) {
+        if (!moduleId || !held.delete(pitch)) return
+        RackEngine.sendEvent(handle, moduleId, 'note', { type: 'note-off', note: pitch, time: ctx.currentTime })
+      },
+      send(event) {
+        ensureMounted()
+        if (!moduleId) return
+        RackEngine.sendEvent(handle, moduleId, 'note', event)
+      },
+      dispose() {
+        if (handle) RackEngine.unmount(handle)
+        handle = null
+        moduleId = null
+        held.clear()
+      }
+    }
+  }
+
+  const palette = palettes?.[instrument.paletteKey || track.paletteKey || 'classic']
+  if (!palette) return null
+
+  const voices = new Map() // pitch → voice
+  return {
+    noteOn(pitch, velocity) {
+      if (voices.has(pitch)) return
+      const freq = 440 * Math.pow(2, (pitch - 69) / 12)
+      voices.set(pitch, palette.createVoice(ctx, output, freq, velocity / 127, ctx.currentTime))
+    },
+    noteOff(pitch) {
+      const voice = voices.get(pitch)
+      if (!voice) return
+      voice.stop(ctx.currentTime)
+      voices.delete(pitch)
+    },
+    send() {},
+    dispose() {
+      for (const voice of voices.values()) voice.stop(ctx.currentTime)
+      voices.clear()
+    }
+  }
+}

--- a/src/renderer/js/midi/midi-message.js
+++ b/src/renderer/js/midi/midi-message.js
@@ -1,0 +1,39 @@
+/**
+ * midi-message.js
+ * Pure parser: raw MIDI bytes -> a typed event object, or null if unhandled.
+ * channel is `status & 0x0f`, 0-indexed (device channel 1 = channel: 0).
+ * Never re-index channel anywhere else — this is the one place that reads it.
+ */
+
+export function parseMidiMessage(bytes) {
+  const [status, data1, data2] = bytes
+  const type = status & 0xf0
+  const channel = status & 0x0f
+
+  if (type === 0x90) {
+    const velocity = data2
+    if (velocity > 0) return { kind: 'note-on', channel, pitch: data1, velocity }
+    return { kind: 'note-off', channel, pitch: data1 }
+  }
+
+  if (type === 0x80) {
+    return { kind: 'note-off', channel, pitch: data1 }
+  }
+
+  if (type === 0xb0) {
+    return { kind: 'cc', channel, controller: data1, value: data2 }
+  }
+
+  if (type === 0xe0) {
+    const raw = (data2 << 7) | data1
+    const value = raw === 8192 ? 0 : raw < 8192 ? (raw - 8192) / 8192 : (raw - 8192) / 8191
+    return { kind: 'pitch-bend', channel, value }
+  }
+
+  if (status === 0xf8) return { kind: 'clock' }
+  if (status === 0xfa) return { kind: 'start' }
+  if (status === 0xfc) return { kind: 'stop' }
+  if (status === 0xfb) return { kind: 'continue' }
+
+  return null
+}

--- a/src/renderer/js/midi/midi-routing.js
+++ b/src/renderer/js/midi/midi-routing.js
@@ -1,0 +1,11 @@
+// midi-routing.js — pure channel → track routing.
+// Layering (rule 1) and omni fallback (rule 2) both intentional; see
+// specs/midi-bridge.md Phase 2.
+
+export function routeChannel(tracks, channel, armedTrackId) {
+  const declared = tracks.filter(t => (t.midiChannel ?? null) === channel).map(t => t.id)
+  if (declared.length) return declared
+  const anyDeclared = tracks.some(t => (t.midiChannel ?? null) !== null)
+  if (!anyDeclared) return armedTrackId != null ? [armedTrackId] : []
+  return []
+}

--- a/src/renderer/js/store/ProjectStore.js
+++ b/src/renderer/js/store/ProjectStore.js
@@ -105,6 +105,23 @@ export function AddTrack(type = 'audio', name = 'Track') {
   }
 }
 
+export function SetTrackMidiChannel(trackId, channel) {
+  return {
+    label: `Set track MIDI channel`,
+    execute(state) {
+      const next = JSON.parse(JSON.stringify(state))
+      const track = next.tracks.find(t => t.id === trackId)
+      if (!track) return next
+      if (typeof channel === 'number' && channel >= 0 && channel <= 15) track.midiChannel = channel
+      else delete track.midiChannel
+      return next
+    },
+    undo(state) {
+      return state
+    }
+  }
+}
+
 export function RemoveTrack(trackId) {
   return {
     label: `Remove track`,

--- a/src/renderer/js/store/ProjectStore.js
+++ b/src/renderer/js/store/ProjectStore.js
@@ -122,6 +122,23 @@ export function SetTrackMidiChannel(trackId, channel) {
   }
 }
 
+export function SetTrackInstrument(trackId, instrument) {
+  return {
+    label: `Set track instrument`,
+    execute(state) {
+      const next = JSON.parse(JSON.stringify(state))
+      const track = next.tracks.find(t => t.id === trackId)
+      if (!track || !instrument) return next
+      if (instrument.type === 'rack' && !(next.racks || {})[instrument.rackId]) return state
+      track.instrument = { ...instrument }
+      return next
+    },
+    undo(state) {
+      return state
+    }
+  }
+}
+
 export function RemoveTrack(trackId) {
   return {
     label: `Remove track`,

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -1596,6 +1596,13 @@ button { font-family: var(--font-mono); }
   border-color: var(--accent);
   color: var(--accent);
 }
+.track-header-item .track-midi-ch {
+  width: 52px;
+  font-size: 9px;
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+}
 /* ── Arrangement scrollbars ──────────────────────────────────────────────── */
 .arr-scrollbar {
   position: absolute;

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -1603,6 +1603,13 @@ button { font-family: var(--font-mono); }
   border: 1px solid var(--border);
   color: var(--text-dim);
 }
+.track-header-item .track-instrument {
+  width: 90px;
+  font-size: 9px;
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+}
 /* ── Arrangement scrollbars ──────────────────────────────────────────────── */
 .arr-scrollbar {
   position: absolute;

--- a/tests/midi-message.test.js
+++ b/tests/midi-message.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { parseMidiMessage } from '../src/renderer/js/midi/midi-message.js'
+
+describe('note-on', () => {
+  it('parses a note-on with velocity > 0', () => {
+    expect(parseMidiMessage([0x90, 60, 100])).toEqual({ kind: 'note-on', channel: 0, pitch: 60, velocity: 100 })
+  })
+
+  it('velocity 0 parses as note-off', () => {
+    expect(parseMidiMessage([0x90, 60, 0])).toEqual({ kind: 'note-off', channel: 0, pitch: 60 })
+  })
+
+  it('channel nibble survives on channel 15', () => {
+    expect(parseMidiMessage([0x9f, 60, 100])).toEqual({ kind: 'note-on', channel: 15, pitch: 60, velocity: 100 })
+  })
+})
+
+describe('note-off', () => {
+  it('parses a 0x80 note-off', () => {
+    expect(parseMidiMessage([0x80, 60, 0])).toEqual({ kind: 'note-off', channel: 0, pitch: 60 })
+  })
+
+  it('channel nibble survives on channel 15', () => {
+    expect(parseMidiMessage([0x8f, 60, 0])).toEqual({ kind: 'note-off', channel: 15, pitch: 60 })
+  })
+})
+
+describe('cc', () => {
+  it('parses controller and raw value', () => {
+    expect(parseMidiMessage([0xb0, 7, 100])).toEqual({ kind: 'cc', channel: 0, controller: 7, value: 100 })
+  })
+
+  it('channel nibble survives on channel 15', () => {
+    expect(parseMidiMessage([0xbf, 7, 100])).toEqual({ kind: 'cc', channel: 15, controller: 7, value: 100 })
+  })
+})
+
+describe('pitch-bend', () => {
+  it('centre (8192) normalises to exactly 0', () => {
+    expect(parseMidiMessage([0xe0, 0, 64])).toEqual({ kind: 'pitch-bend', channel: 0, value: 0 })
+  })
+
+  it('minimum bends to exactly -1', () => {
+    expect(parseMidiMessage([0xe0, 0, 0])).toEqual({ kind: 'pitch-bend', channel: 0, value: -1 })
+  })
+
+  it('maximum bends to exactly +1', () => {
+    expect(parseMidiMessage([0xe0, 127, 127])).toEqual({ kind: 'pitch-bend', channel: 0, value: 1 })
+  })
+
+  it('channel nibble survives on channel 15', () => {
+    expect(parseMidiMessage([0xef, 0, 64])).toEqual({ kind: 'pitch-bend', channel: 15, value: 0 })
+  })
+})
+
+describe('realtime', () => {
+  it('parses clock', () => {
+    expect(parseMidiMessage([0xf8])).toEqual({ kind: 'clock' })
+  })
+
+  it('parses start', () => {
+    expect(parseMidiMessage([0xfa])).toEqual({ kind: 'start' })
+  })
+
+  it('parses stop', () => {
+    expect(parseMidiMessage([0xfc])).toEqual({ kind: 'stop' })
+  })
+
+  it('parses continue', () => {
+    expect(parseMidiMessage([0xfb])).toEqual({ kind: 'continue' })
+  })
+})
+
+describe('unhandled', () => {
+  it('returns null for sysex', () => {
+    expect(parseMidiMessage([0xf0, 0x7e, 0xf7])).toBe(null)
+  })
+
+  it('returns null for aftertouch', () => {
+    expect(parseMidiMessage([0xa0, 60, 100])).toBe(null)
+  })
+
+  it('returns null for program change', () => {
+    expect(parseMidiMessage([0xc0, 5])).toBe(null)
+  })
+})

--- a/tests/midi-routing.test.js
+++ b/tests/midi-routing.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { routeChannel } from '../src/renderer/js/midi/midi-routing.js'
+
+function track(id, midiChannel) {
+  return midiChannel === undefined ? { id } : { id, midiChannel }
+}
+
+describe('routeChannel', () => {
+  it('returns all tracks declared on the channel', () => {
+    const tracks = [track('a', 0), track('b', 0), track('c', 1)]
+    expect(routeChannel(tracks, 0, null)).toEqual(['a', 'b'])
+  })
+
+  it('channel 0 counts as declared', () => {
+    const tracks = [track('a', 0)]
+    expect(routeChannel(tracks, 5, 'armed')).toEqual([])
+  })
+
+  it('falls back to armed track when nothing declares a channel', () => {
+    const tracks = [track('a'), track('b')]
+    expect(routeChannel(tracks, 3, 'armed')).toEqual(['armed'])
+  })
+
+  it('omni fallback with no armed track returns empty', () => {
+    const tracks = [track('a'), track('b')]
+    expect(routeChannel(tracks, 3, null)).toEqual([])
+  })
+
+  it('returns empty when a routing map exists but channel is unmapped', () => {
+    const tracks = [track('a', 0), track('b')]
+    expect(routeChannel(tracks, 5, 'armed')).toEqual([])
+  })
+})

--- a/tests/rack-midi.test.js
+++ b/tests/rack-midi.test.js
@@ -1,5 +1,19 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import midiIn, { allocateVoice } from '../src/renderer/js/rack/modules/midi-in.js'
+
+function makeCtx() {
+  const param = () => ({ value: 0, setValueAtTime: vi.fn(), setTargetAtTime: vi.fn(), cancelScheduledValues: vi.fn() })
+  return {
+    currentTime: 0,
+    createConstantSource: () => ({
+      offset: param(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn()
+    })
+  }
+}
 
 describe('MIDI IN allocation', () => {
   it('rotates through voices and steals at the cursor', () => {
@@ -25,5 +39,23 @@ describe('MIDI IN allocation', () => {
 
   it('is registered as the polyphonic native source', () => {
     expect(midiIn.polySource({ params: { voices: 3 } })).toBe(3)
+  })
+})
+
+describe('MIDI IN mod + pitch bend', () => {
+  it('writes a mod event to every mod output', () => {
+    const inst = midiIn.create(makeCtx(), { channels: 3, params: {} })
+    inst.onEvent('note', { type: 'mod', value: 0.5, time: 0 })
+    for (const node of inst.outputs.mod) {
+      expect(node.offset.setValueAtTime).toHaveBeenCalledWith(0.5, 0)
+    }
+  })
+
+  it('scales pitch bend by bendRange / 24', () => {
+    const inst = midiIn.create(makeCtx(), { channels: 2, params: { bendRange: 2 } })
+    inst.onEvent('note', { type: 'pitch-bend', value: 1, time: 0 })
+    for (const node of inst.outputs.pb) {
+      expect(node.offset.setValueAtTime).toHaveBeenCalledWith(2 / 24, 0)
+    }
   })
 })

--- a/tests/store-midi.test.js
+++ b/tests/store-midi.test.js
@@ -4,7 +4,8 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import ProjectStore, {
   AddTrack, AddClip,
-  AddMidiNote, RemoveMidiNote, MoveMidiNote, ResizeMidiNote, SetMidiNoteVelocity
+  AddMidiNote, RemoveMidiNote, MoveMidiNote, ResizeMidiNote, SetMidiNoteVelocity,
+  SetTrackMidiChannel
 } from '../src/renderer/js/store/ProjectStore.js'
 
 function makeNote(overrides = {}) {
@@ -106,6 +107,30 @@ describe('SetMidiNoteVelocity', () => {
     expect(ProjectStore.getState().tracks[0].clips[0].notes[0].velocity).toBe(1)
     ProjectStore.dispatch(SetMidiNoteVelocity(trackId, clipId, 'n1', -0.5))
     expect(ProjectStore.getState().tracks[0].clips[0].notes[0].velocity).toBe(0.01)
+  })
+})
+
+describe('SetTrackMidiChannel', () => {
+  it('sets the channel', () => {
+    ProjectStore.dispatch(AddTrack('midi', 'MIDI'))
+    const trackId = ProjectStore.getState().tracks[0].id
+    ProjectStore.dispatch(SetTrackMidiChannel(trackId, 3))
+    expect(ProjectStore.getState().tracks[0].midiChannel).toBe(3)
+  })
+
+  it('null removes the field', () => {
+    ProjectStore.dispatch(AddTrack('midi', 'MIDI'))
+    const trackId = ProjectStore.getState().tracks[0].id
+    ProjectStore.dispatch(SetTrackMidiChannel(trackId, 3))
+    ProjectStore.dispatch(SetTrackMidiChannel(trackId, null))
+    expect(ProjectStore.getState().tracks[0].midiChannel).toBeUndefined()
+    expect('midiChannel' in ProjectStore.getState().tracks[0]).toBe(false)
+  })
+
+  it('no-ops for an unknown track id', () => {
+    ProjectStore.dispatch(AddTrack('midi', 'MIDI'))
+    ProjectStore.dispatch(SetTrackMidiChannel('ghost', 3))
+    expect(ProjectStore.getState().tracks[0].midiChannel).toBeUndefined()
   })
 })
 

--- a/tests/store-midi.test.js
+++ b/tests/store-midi.test.js
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import ProjectStore, {
   AddTrack, AddClip,
   AddMidiNote, RemoveMidiNote, MoveMidiNote, ResizeMidiNote, SetMidiNoteVelocity,
-  SetTrackMidiChannel
+  SetTrackMidiChannel, SetTrackInstrument, AddRack
 } from '../src/renderer/js/store/ProjectStore.js'
 
 function makeNote(overrides = {}) {
@@ -131,6 +131,36 @@ describe('SetTrackMidiChannel', () => {
     ProjectStore.dispatch(AddTrack('midi', 'MIDI'))
     ProjectStore.dispatch(SetTrackMidiChannel('ghost', 3))
     expect(ProjectStore.getState().tracks[0].midiChannel).toBeUndefined()
+  })
+})
+
+describe('SetTrackInstrument', () => {
+  it('sets a palette instrument', () => {
+    ProjectStore.dispatch(AddTrack('midi', 'MIDI'))
+    const trackId = ProjectStore.getState().tracks[0].id
+    ProjectStore.dispatch(SetTrackInstrument(trackId, { type: 'palette', paletteKey: 'fm' }))
+    expect(ProjectStore.getState().tracks[0].instrument).toEqual({ type: 'palette', paletteKey: 'fm' })
+  })
+
+  it('sets a rack instrument when the rack exists', () => {
+    ProjectStore.dispatch(AddTrack('midi', 'MIDI'))
+    const trackId = ProjectStore.getState().tracks[0].id
+    ProjectStore.dispatch(AddRack('My Rack', 'rack1'))
+    ProjectStore.dispatch(SetTrackInstrument(trackId, { type: 'rack', rackId: 'rack1' }))
+    expect(ProjectStore.getState().tracks[0].instrument).toEqual({ type: 'rack', rackId: 'rack1' })
+  })
+
+  it('ignores a rackId that is not in state.racks', () => {
+    ProjectStore.dispatch(AddTrack('midi', 'MIDI'))
+    const trackId = ProjectStore.getState().tracks[0].id
+    ProjectStore.dispatch(SetTrackInstrument(trackId, { type: 'rack', rackId: 'ghost' }))
+    expect(ProjectStore.getState().tracks[0].instrument).toEqual({ type: 'palette', paletteKey: 'classic' })
+  })
+
+  it('no-ops for an unknown track id', () => {
+    ProjectStore.dispatch(AddTrack('midi', 'MIDI'))
+    ProjectStore.dispatch(SetTrackInstrument('ghost', { type: 'palette', paletteKey: 'fm' }))
+    expect(ProjectStore.getState().tracks[0].instrument).toEqual({ type: 'palette', paletteKey: 'classic' })
   })
 })
 


### PR DESCRIPTION
Implements phases 1–3 of `specs/midi-bridge.md` — the bridge that lets an external sequencer (Midinous, hardware, any DAW over a loopback port) drive the app per channel.

## Phase 1 — pure message parser (`3665564`)
`midi/midi-message.js` turns raw bytes into typed events: `note-on`/`note-off` (velocity-0 note-on folded into note-off), `cc`, `pitch-bend` (14-bit, centre exactly 0, extremes ±1) and `clock`/`start`/`stop`/`continue`. Channel is `status & 0x0f`, 0-indexed, read in exactly one place. `MidiController` now dispatches a single `midi-event` on `document`; the legacy `midi-note-on`/`midi-note-off` events and the recording path are unchanged.

## Phase 2 — channel routing + live instruments (`c9ddf05`)
- `midi/midi-routing.js` — pure `routeChannel(tracks, channel, armedTrackId)`. Tracks claiming the channel win (all of them — layering is free); if no track declares a channel at all it falls back to the armed track, so plugging in a keyboard still just plays; otherwise silence.
- `midi/live-instrument.js` — plays one track live. Palette tracks make voices directly; rack tracks mount lazily and drive their `midi-in` module in the event domain.
- Track headers gain an Omni/1–16 select backed by a new `SetTrackMidiChannel` command. `midiChannel` is optional, so no schema bump and no `migrate()` step.

## Phase 3 — CC + bend into racks (`76214f1`)
Mod wheel (CC1) drives the `midi-in` MOD output, pitch bend the PB output. The module already scales bend by `bendRange / 24`, so the raw -1..1 value passes straight through.

Phases 4 (clock in) and 5 (MIDI out) are deliberately not built — spec says wait until drift bites or real gear is listening.

## Test
`npm test` — 60 files, 920 passed. New: `tests/midi-message.test.js`, `tests/midi-routing.test.js`; extended: `tests/store-midi.test.js`, `tests/rack-midi.test.js`.

Manual acceptance needs a secure context (Electron `npm run dev` or `https://synth.zakharhome.org`) — Web MIDI does not exist on the LAN http route, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnybePT3GgGadfzHxPJc4U